### PR TITLE
Change designer news login theme to provide a dialog like UI experience

### DIFF
--- a/designernews/src/main/res/values/styles.xml
+++ b/designernews/src/main/res/values/styles.xml
@@ -22,6 +22,10 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:windowMinWidthMajor">100%</item>
+        <item name="android:windowMinWidthMinor">100%</item>
         <item name="android:colorPrimary">@color/designer_news</item>
         <item name="android:colorAccent">@color/designer_news</item>
         <item name="android:colorButtonNormal">@color/designer_news_button</item>


### PR DESCRIPTION

Fixes #444 

The `Plaid.Translucent.DesignerNewsLogin` style is currently deriving `android:windowBackground` attribute which is causing the shadow background. 

I changed the `android:windowBackground` to transparent and set `android:windowIsFloating` to true.

For some reason setting `android:windowIsFloating` to true has a weird effect on the width of the Activity.

![screenshot-2019-03-25_18 43 50 095](https://user-images.githubusercontent.com/16693039/54965485-fb50a600-4f2d-11e9-9b26-4520053a4581.png)

so I set `android:windowMinWidthMajor` and `android:windowMinWidthMinor` explicitly.



### **Current Implementation**
![Current Implementation](https://user-images.githubusercontent.com/16693039/54965326-4ddd9280-4f2d-11e9-94db-bc7a3455ce2f.gif)



### **After Changes**
![After changes](https://user-images.githubusercontent.com/16693039/54965288-25559880-4f2d-11e9-8055-b4cc42cf37d8.gif)
