### PR TITLE
Ensure ImageView.drawable is not null before attempting to darken it.

### DIFF
--- a/core/src/main/java/io/plaidapp/core/ui/transitions/DarkenImage.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/transitions/DarkenImage.kt
@@ -59,6 +59,7 @@ class DarkenImage(context: Context, attrs: AttributeSet) : Transition(context, a
         if (!isDarkTheme) return null
         if (initialRgbScale == finalRgbScale) return null
         val iv = endValues?.view as? ImageView ?: return null
+        if (iv.drawable == null) return null
         return ValueAnimator.ofFloat(initialRgbScale, finalRgbScale).apply {
             addUpdateListener { listener ->
                 val cm = ColorMatrix()

--- a/core/src/main/java/io/plaidapp/core/ui/transitions/DarkenImage.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/transitions/DarkenImage.kt
@@ -59,13 +59,13 @@ class DarkenImage(context: Context, attrs: AttributeSet) : Transition(context, a
         if (!isDarkTheme) return null
         if (initialRgbScale == finalRgbScale) return null
         val iv = endValues?.view as? ImageView ?: return null
-        if (iv.drawable == null) return null
+        val drawable = iv.drawable ?: return null
         return ValueAnimator.ofFloat(initialRgbScale, finalRgbScale).apply {
             addUpdateListener { listener ->
                 val cm = ColorMatrix()
                 val rgbScale = listener.animatedValue as Float
                 cm.setScale(rgbScale, rgbScale, rgbScale, ALPHA_SCALE)
-                iv.drawable.colorFilter = ColorMatrixColorFilter(cm)
+                drawable.colorFilter = ColorMatrixColorFilter(cm)
             }
         }
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Check if the `drawable` in an `ImageView` is `null` before creating an `Animator` over it in the `DarkenImage` transition.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #691

## :green_heart: How did you test it?
Manually on device.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
