### PR TITLE
Deduplicate configuration of repositories in build.gradle files

### DIFF
--- a/about/build.gradle
+++ b/about/build.gradle
@@ -22,8 +22,6 @@ apply plugin: 'kotlin-kapt'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,6 @@ apply plugin: 'kotlin-kapt'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,10 @@ ext {
 }
 
 subprojects {
+    buildscript {
+        apply from: rootProject.file('repositories.gradle')
+    }
+
     apply plugin: 'com.diffplug.gradle.spotless'
     spotless {
         kotlin {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,8 +23,6 @@ apply plugin: 'kotlin-kapt'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -23,8 +23,6 @@ apply plugin: 'kotlin-kapt'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -22,8 +22,6 @@ apply plugin: 'kotlin-kapt'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -22,8 +22,6 @@ apply plugin: 'kotlin-kapt'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/test_shared/build.gradle
+++ b/test_shared/build.gradle
@@ -21,8 +21,6 @@ apply plugin: 'kotlin-android'
 apply from: '../core_dependencies.gradle'
 apply from: '../test_dependencies.gradle'
 
-apply from: '../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 

--- a/third_party/bypass/build.gradle
+++ b/third_party/bypass/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-apply from: '../../repositories.gradle'
-
 android {
     compileSdkVersion versions.compileSdk
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The following line has been extracted from all `build.gradle` files into the `subprojects {}` block.

```
apply from: '../repositories.gradle'
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was looking through #615 and spotted that all `build.gradle` files have the `apply from: 'repositories.gradle'` line. This change is just reducing the clutter in each of the `build.gradle` files.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
1. All modules have similar `android { defaultConfig }` configuration which could also be deduplicated and extracted into the `subprojects {}` block. Let me know if this is something worth doing.
2. `apply plugin: 'kotlin-android'` can also be extracted to `subprojects {}` but that would bring issues if some non-Android modules are planned.
