### PR TITLE
[DO NOT MERGE] Adds TestCoroutineDispatcher + LiveData coroutines support

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/HomeViewModel.kt
+++ b/app/src/main/java/io/plaidapp/ui/HomeViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.DataLoadingSubject
@@ -109,10 +110,10 @@ class HomeViewModel(
 
     fun getFeed(columns: Int): LiveData<FeedUiModel> {
         return Transformations.switchMap(feedData) {
-            // TODO move this on a background thread
-            //  https://github.com/nickbutcher/plaid/issues/658
-            expandPopularItems(it, columns)
-            return@switchMap MutableLiveData(FeedUiModel(it))
+            return@switchMap liveData(viewModelScope.coroutineContext + dispatcherProvider.computation) {
+                expandPopularItems(it, columns)
+                emit(FeedUiModel(it))
+            }
         }
     }
 

--- a/app/src/test/java/io/plaidapp/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/io/plaidapp/ui/HomeViewModelTest.kt
@@ -42,10 +42,12 @@ import io.plaidapp.dribbbleSource
 import io.plaidapp.post
 import io.plaidapp.shot
 import io.plaidapp.story
-import io.plaidapp.test.shared.CoroutinesMainDispatcherRule
+import io.plaidapp.test.shared.CoroutinesTestRule
 import io.plaidapp.test.shared.LiveDataTestUtil
 import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -57,10 +59,12 @@ import org.mockito.MockitoAnnotations
 /**
  * Tests for [HomeViewModel], with dependencies mocked.
  */
+@ExperimentalCoroutinesApi
 class HomeViewModelTest {
 
+    // Set the main coroutines dispatcher for unit testing
     @get:Rule
-    var coroutinesMainDispatcherRule = CoroutinesMainDispatcherRule()
+    var coroutinesTestRule = CoroutinesTestRule()
 
     // Executes tasks in the Architecture Components in the same thread
     @get:Rule
@@ -278,7 +282,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun filtersRemoved() {
+    fun filtersRemoved() = coroutinesTestRule.testDispatcher.runBlockingTest {
         // Given a view model with feed data
         val homeViewModel = createViewModelWithFeedData(listOf(post, shot, story))
         verify(sourcesRepository).registerFilterChangedCallback(
@@ -294,7 +298,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun filtersChanged_activeSource() {
+    fun filtersChanged_activeSource() = coroutinesTestRule.testDispatcher.runBlockingTest {
         // Given a view model with feed data
         val homeViewModel = createViewModelWithFeedData(listOf(post, shot, story))
         verify(sourcesRepository).registerFilterChangedCallback(
@@ -312,7 +316,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun filtersChanged_inactiveSource() {
+    fun filtersChanged_inactiveSource() = coroutinesTestRule.testDispatcher.runBlockingTest {
         // Given a view model with feed data
         val homeViewModel = createViewModelWithFeedData(listOf(post, shot, story))
         verify(sourcesRepository).registerFilterChangedCallback(
@@ -357,7 +361,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun dataLoading_atInit() = runBlocking {
+    fun dataLoading_atInit() = coroutinesTestRule.testDispatcher.runBlockingTest {
         // When creating a view model
         createViewModel()
 
@@ -366,7 +370,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun feed_emitsWhenDataLoaded() {
+    fun feed_emitsWhenDataLoaded() = coroutinesTestRule.testDispatcher.runBlockingTest {
         // Given a view model
         val homeViewModel = createViewModel()
         verify(dataManager).setOnDataLoadedCallback(capture(dataLoadedCallback))
@@ -391,13 +395,17 @@ class HomeViewModelTest {
 
     private fun createViewModel(
         list: List<SourceItem> = emptyList()
-    ): HomeViewModel = runBlocking {
-        whenever(sourcesRepository.getSources()).thenReturn(list)
-        return@runBlocking HomeViewModel(
+    ): HomeViewModel {
+        runBlocking { whenever(sourcesRepository.getSources()).thenReturn(list) }
+        return HomeViewModel(
             dataManager,
             loginRepository,
             sourcesRepository,
-            provideFakeCoroutinesDispatcherProvider()
+            provideFakeCoroutinesDispatcherProvider(
+                coroutinesTestRule.testDispatcher,
+                coroutinesTestRule.testDispatcher,
+                coroutinesTestRule.testDispatcher
+            )
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript { scriptHandler ->
             'kotlin'             : '1.3.20',
             'ktlint'             : '0.24.0',
             'legacyCoreUtils'    : '1.0.0',
-            'lifecycle'          : '2.1.0-alpha01',
+            'lifecycle'          : '2.2.0-alpha01',
             'material'           : '1.1.0-alpha05',
             'mockito'            : '2.23.0',
             'mockito_kotlin'     : '2.0.0-RC3',
@@ -62,7 +62,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-rc02'
+        classpath 'com.android.tools.build:gradle:3.5.0-alpha06'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript { scriptHandler ->
             'androidxArch'       : '2.0.0',
             'constraintLayout'   : '2.0.0-alpha2',
             'coreKtx'            : '1.0.0',
-            'coroutines'         : '1.1.1',
+            'coroutines'         : '1.2.1',
             'crashlytics'        : '2.9.8',
             'dagger'             : '2.16',
             'espresso'           : '3.1.0-beta02',

--- a/core_dependencies.gradle
+++ b/core_dependencies.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:${versions.retrofitCoroutines}"
     implementation "org.jsoup:jsoup:${versions.jsoup}"
     implementation "androidx.lifecycle:lifecycle-viewmodel:${versions.lifecycle}"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:${versions.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.lifecycle}"
 }

--- a/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -59,6 +60,11 @@ class ShotViewModelTest {
         on { runBlocking { invoke(any()) } } doReturn testShotUiModel
     }
     private val testCoroutineDispatcher = TestCoroutineDispatcher()
+
+    @After
+    fun tearDown() {
+        testCoroutineDispatcher.cleanupTestCoroutines()
+    }
 
     @Test
     fun loadShot_existsInRepo() {

--- a/search/src/main/java/io/plaidapp/search/domain/LoadSearchDataUseCase.kt
+++ b/search/src/main/java/io/plaidapp/search/domain/LoadSearchDataUseCase.kt
@@ -18,6 +18,7 @@ package io.plaidapp.search.domain
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.liveData
 import io.plaidapp.core.data.PlaidItem
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.interfaces.SearchDataSourceFactory

--- a/test_shared/src/main/java/io/plaidapp/test/shared/CoroutinesTestRule.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/CoroutinesTestRule.kt
@@ -18,26 +18,25 @@ package io.plaidapp.test.shared
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
-import java.util.concurrent.Executors
 
 @ExperimentalCoroutinesApi
-class CoroutinesMainDispatcherRule : TestWatcher() {
-
-    private val singleThreadExecutor = Executors.newSingleThreadExecutor()
+class CoroutinesTestRule(
+    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : TestWatcher() {
 
     override fun starting(description: Description?) {
         super.starting(description)
-        Dispatchers.setMain(singleThreadExecutor.asCoroutineDispatcher())
+        Dispatchers.setMain(testDispatcher)
     }
 
     override fun finished(description: Description?) {
         super.finished(description)
-        singleThreadExecutor.shutdownNow()
         Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
     }
 }

--- a/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
@@ -20,9 +20,12 @@ import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.Unconfined
 
+// Using Unconfined here as a way to execute coroutines in tests in the test thread.
+// That makes the test to wait for the coroutine to finish before carry on.
+// This needs to be improved in the future, either using a CoroutinesMainDispatcherRule
+// or the recently added TestCoroutineDispatcher when it hits stable.
 fun provideFakeCoroutinesDispatcherProvider(
     main: CoroutineDispatcher = Unconfined,
     computation: CoroutineDispatcher = Unconfined,
     io: CoroutineDispatcher = Unconfined
-
 ): CoroutinesDispatcherProvider = CoroutinesDispatcherProvider(main, computation, io)

--- a/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.Dispatchers.Unconfined
 
 // Using Unconfined here as a way to execute coroutines in tests in the test thread.
 // That makes the test to wait for the coroutine to finish before carry on.
-// This needs to be improved in the future, either using a CoroutinesMainDispatcherRule
+// This needs to be improved in the future, either using a CoroutinesTestRule
 // or the recently added TestCoroutineDispatcher when it hits stable.
 fun provideFakeCoroutinesDispatcherProvider(
     main: CoroutineDispatcher = Unconfined,

--- a/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
@@ -17,7 +17,12 @@
 package io.plaidapp.test.shared
 
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.Unconfined
 
-fun provideFakeCoroutinesDispatcherProvider(): CoroutinesDispatcherProvider =
-    CoroutinesDispatcherProvider(Unconfined, Unconfined, Unconfined)
+fun provideFakeCoroutinesDispatcherProvider(
+    main: CoroutineDispatcher = Unconfined,
+    computation: CoroutineDispatcher = Unconfined,
+    io: CoroutineDispatcher = Unconfined
+
+): CoroutinesDispatcherProvider = CoroutinesDispatcherProvider(main, computation, io)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Used the new experimental TestCoroutineDispatcher to fix #655.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before, we didn't have the option to stop / resume the CoroutinesDispatcher when injected with our `CoroutinesDispatcherProvider` so we couldn't test logic that relies on that.

## :green_heart: How did you test it?
Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
When the API hits stable, we'll migrate all the tests to use this. `runBlocking` in tests should migrate to `runBlockingTest`.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
