### PR TITLE
Restore icon on save search confirmation step.

### DIFF
--- a/search/src/main/res/layout/activity_search.xml
+++ b/search/src/main/res/layout/activity_search.xml
@@ -174,7 +174,7 @@
                     android:text="@string/confirm_save_designer_news_search"
                     android:textAppearance="?attr/textAppearanceBody2" />
 
-                <Button
+                <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/save_confirmed"
                     style="?android:borderlessButtonStyle"
                     android:layout_width="wrap_content"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :bulb: Motivation and Context
In the move to `MaterialComponents` theme, `<Button>`s are now inflated as `MaterialButton`s which ignore the `drawableEnd`. `MaterialButton` does support an `app:icon` attribute but the [docs](https://material.io/develop/android/components/material-button/) discourage you from setting an `iconGravity` of `end`, which is what we want here to maintain the position of the save icon from the collapsed FAB to the expanded confirmation step. Instead I switched it to an `AppCompatButton` so that the material inflater factory does not attempt to substitute it with a `MaterialButton`.

Fixes #698 


## :green_heart: How did you test it?
Manually


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
None.


## :camera_flash: Screenshots / GIFs
![search_save_icon_fix](https://user-images.githubusercontent.com/352556/58246557-50067680-7d4f-11e9-9d56-1344cd43a1c5.gif)