### PR TITLE
Fix GIF badge on Dribbble shots.

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dribbble/data/search/DribbbleSearchConverter.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/search/DribbbleSearchConverter.kt
@@ -70,7 +70,7 @@ object DribbbleSearchConverter : Converter<ResponseBody, List<Shot>> {
         if (imgUrl.contains("_teaser.")) {
             imgUrl = imgUrl.replace("_teaser.", ".")
         }
-        val animated = element.select("div.gif-indicator").first() != null
+        val animated = imgUrl?.endsWith(".gif", ignoreCase = true) ?: false
         val createdAt: Date? = try {
             DATE_FORMAT.parse(descriptionBlock.select("em.timestamp").first().text())
         } catch (e: ParseException) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Restore the GIF indicator on Dribbble images in the grid.


## :bulb: Motivation and Context
We were previously looking for a certain css class which seems to have changed. Altered the `DribbbleSearchConverter` (gross 😷) logic to look for images with a `.gif` extension.

Fixes #699 


## :green_heart: How did you test it?
Manually.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
none

## :camera_flash: Screenshots / GIFs
![Screenshot_1558609426](https://user-images.githubusercontent.com/352556/58248232-82b26e00-7d53-11e9-8a77-a173e9a55291.png)

