### PR TITLE
Fixes Dribbble description animation

### DIFF
--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
@@ -18,6 +18,7 @@ package io.plaidapp.dribbble.ui.shot
 
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.text.format.DateUtils
+import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.PluralsRes
@@ -67,7 +68,10 @@ fun bindHtmlText(
     textView: TextView,
     htmlText: CharSequence?
 ) {
-    if (htmlText == null) return
+    if (htmlText == null) {
+        textView.visibility = View.GONE
+        return
+    }
     HtmlUtils.setTextWithNiceLinks(textView, htmlText)
 }
 

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
@@ -69,7 +69,6 @@ fun bindHtmlText(
     htmlText: CharSequence?
 ) {
     if (htmlText == null) {
-        // Fixes #675
         textView.visibility = GONE
         return
     }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
@@ -18,7 +18,7 @@ package io.plaidapp.dribbble.ui.shot
 
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.text.format.DateUtils
-import android.view.View
+import android.view.View.GONE
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.PluralsRes
@@ -63,13 +63,14 @@ fun bindImage(
     request.into(imageView)
 }
 
-@BindingAdapter("htmlText")
+@BindingAdapter("htmlTextOrGone")
 fun bindHtmlText(
     textView: TextView,
     htmlText: CharSequence?
 ) {
     if (htmlText == null) {
-        textView.visibility = View.GONE
+        // Fixes #675
+        textView.visibility = GONE
         return
     }
     HtmlUtils.setTextWithNiceLinks(textView, htmlText)

--- a/dribbble/src/main/res/layout/activity_dribbble_shot.xml
+++ b/dribbble/src/main/res/layout/activity_dribbble_shot.xml
@@ -165,7 +165,7 @@
                     android:textAppearance="@style/TextAppearance.DribbbleShotDescription"
                     android:textColorHighlight="@color/dribbble_link_highlight"
                     android:textColorLink="@color/dribbble_links"
-                    app:htmlText="@{uiModel.formattedDescription}"
+                    app:htmlTextOrGone="@{uiModel.formattedDescription}"
                     tools:text="Check out this sweet eye candy!" />
 
                 <io.plaidapp.core.ui.widget.BaselineGridTextView

--- a/dribbble/src/main/res/layout/activity_dribbble_shot.xml
+++ b/dribbble/src/main/res/layout/activity_dribbble_shot.xml
@@ -166,7 +166,6 @@
                     android:textColorHighlight="@color/dribbble_link_highlight"
                     android:textColorLink="@color/dribbble_links"
                     app:htmlText="@{uiModel.formattedDescription}"
-                    app:goneUnless="@{uiModel.shouldHideDescription}"
                     tools:text="Check out this sweet eye candy!" />
 
                 <io.plaidapp.core.ui.widget.BaselineGridTextView


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes Dribbble description animation.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #675 

For some reason, the transition doesn't like the BindingAdapter `goneUnless`. Even if we modify the adapter to only set the new visibility when it changes, the animation stops working. 

My gut tells me that the view is always GONE because we emit a first ShotUiModel with an empty description and then when the description is loaded, we emit another model with description making the animation for that view to stop working. 

That's why the decision is to set the visibility to GONE in the htmlText BindingAdapter when the description is null.

## :green_heart: How did you test it?
Manually.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
None.

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
![fix](https://user-images.githubusercontent.com/7014464/58248481-8696be00-7d5c-11e9-9e05-fb2ea128c75a.gif)

