### PR TITLE
Add tooltip text to dark theme menu toggle

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.java
@@ -55,6 +55,7 @@ import android.widget.Toolbar;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.appcompat.widget.TooltipCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
@@ -363,6 +364,7 @@ public class HomeActivity extends AppCompatActivity {
                     getDelegate().applyDayNight();
                 }, 800L);
             });
+            TooltipCompat.setTooltipText(toggle, getString(R.string.theme));
         }
         setActionBar(toolbar);
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description
Add a tooltip text to the dark theme toggle menu item.  After the change, a long press will show the "Toggle theme" text.

`TooltipCompat.setTooltipText` is needed due to the minApi (23) for the app, as the platform `.setTooltipText` was introduced in API 26.

## :bulb: Motivation and Context
The user can now long press on the dark mode toggle menu item to see what it does.  This functionality now matches the rest of the menu items.

## :green_heart: How did you test it?
Manual

## :pencil: Checklist

- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing

## :crystal_ball: Next steps
N/A

## :camera_flash: Screenshots / GIFs
![Screenshot_1558649682](https://user-images.githubusercontent.com/97128/58290262-fe211900-7d6d-11e9-83ad-ed4712306b9b.png)
