### PR TITLE
Fix layout manager never assigned to grid

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.kt
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.kt
@@ -388,9 +388,8 @@ class HomeActivity : AppCompatActivity() {
             )
             itemAnimator = HomeGridItemAnimator()
             addOnScrollListener(shotPreloader)
+            layoutManager = this@HomeActivity.layoutManager
         }
-
-        layoutManager = grid.layoutManager as GridLayoutManager
     }
 
     private fun handleDrawerInsets(insets: WindowInsets) {


### PR DESCRIPTION
During the refactor of "HomeActivity", the assignment of layoutmanager to "HomeActivity.grid" was missed which caused crash

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
