### PR TITLE
Updates to Retrofit 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ buildscript { scriptHandler ->
             'mockito'            : '2.23.0',
             'mockito_kotlin'     : '2.0.0-RC3',
             'okhttp'             : '3.10.0',
-            'retrofit'           : '2.4.0',
+            'retrofit'           : '2.6.0',
             'retrofitCoroutines' : '0.9.2',
             'room'               : '2.1.0-alpha05',
             'supportLibrary'     : '28.0.0',

--- a/core/src/main/java/io/plaidapp/core/designernews/data/api/DesignerNewsService.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/api/DesignerNewsService.kt
@@ -22,8 +22,6 @@ import io.plaidapp.core.designernews.data.login.model.LoggedInUserResponse
 import io.plaidapp.core.designernews.data.poststory.model.NewStoryRequest
 import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.stories.model.StoryResponse
-import io.plaidapp.core.designernews.data.users.model.User
-import kotlinx.coroutines.Deferred
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
@@ -45,23 +43,19 @@ interface DesignerNewsService {
 
     @EnvelopePayload("stories")
     @GET("api/v2/stories")
-    fun getStories(@Query("page") page: Int?): Deferred<Response<List<StoryResponse>>>
+    suspend fun getStories(@Query("page") page: Int?): Response<List<StoryResponse>>
 
     @EnvelopePayload("stories")
     @GET("api/v2/stories/{ids}")
-    fun getStories(@Path("ids") commaSeparatedIds: String): Deferred<Response<List<StoryResponse>>>
-
-    @EnvelopePayload("users")
-    @GET("api/v2/users/{ids}")
-    fun getUsers(@Path("ids") userids: String): Deferred<Response<List<User>>>
+    suspend fun getStories(@Path("ids") commaSeparatedIds: String): Response<List<StoryResponse>>
 
     @EnvelopePayload("users")
     @GET("api/v2/me")
-    fun getAuthedUser(): Deferred<Response<List<LoggedInUserResponse>>>
+    suspend fun getAuthedUser(): Response<List<LoggedInUserResponse>>
 
     @FormUrlEncoded
     @POST("oauth/token")
-    fun login(@FieldMap loginParams: Map<String, String>): Deferred<Response<AccessToken>>
+    suspend fun login(@FieldMap loginParams: Map<String, String>): Response<AccessToken>
 
     /**
      * Search Designer News by scraping website.
@@ -69,10 +63,10 @@ interface DesignerNewsService {
      */
     @DesignerNewsSearch
     @GET("search?t=story")
-    fun search(
+    suspend fun search(
         @Query("q") query: String,
         @Query("p") page: Int?
-    ): Deferred<Response<List<String>>>
+    ): Response<List<String>>
 
     @EnvelopePayload("story")
     @POST("api/v2/stories/{id}/upvote")

--- a/core/src/main/java/io/plaidapp/core/designernews/data/login/LoginRemoteDataSource.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/login/LoginRemoteDataSource.kt
@@ -47,7 +47,7 @@ class LoginRemoteDataSource @Inject constructor(
     )
 
     private suspend fun requestLogin(username: String, password: String): Result<LoggedInUser> {
-        val response = service.login(buildLoginParams(username, password)).await()
+        val response = service.login(buildLoginParams(username, password))
         if (response.isSuccessful) {
             val body = response.body()
             if (body != null) {
@@ -60,7 +60,7 @@ class LoginRemoteDataSource @Inject constructor(
     }
 
     private suspend fun requestUser(): Result<LoggedInUser> {
-        val response = service.getAuthedUser().await()
+        val response = service.getAuthedUser()
         if (response.isSuccessful) {
             val users = response.body()
             if (users != null && users.isNotEmpty()) {

--- a/core/src/main/java/io/plaidapp/core/designernews/data/stories/StoriesRemoteDataSource.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/stories/StoriesRemoteDataSource.kt
@@ -30,7 +30,7 @@ class StoriesRemoteDataSource(private val service: DesignerNewsService) {
 
     suspend fun loadStories(page: Int): Result<List<StoryResponse>> {
         return try {
-            val response = service.getStories(page).await()
+            val response = service.getStories(page)
             getResult(response = response, onError = {
                 Result.Error(
                     IOException("Error getting stories ${response.code()} ${response.message()}")
@@ -45,7 +45,7 @@ class StoriesRemoteDataSource(private val service: DesignerNewsService) {
         val queryWithoutPrefix =
             query.replace(DesignerNewsSearchSourceItem.DESIGNER_NEWS_QUERY_PREFIX, "")
         return try {
-            val searchResults = service.search(queryWithoutPrefix, page).await()
+            val searchResults = service.search(queryWithoutPrefix, page)
             val ids = searchResults.body()
             if (searchResults.isSuccessful && !ids.isNullOrEmpty()) {
                 val commaSeparatedIds = ids.joinToString(",")
@@ -60,7 +60,7 @@ class StoriesRemoteDataSource(private val service: DesignerNewsService) {
 
     private suspend fun loadStories(commaSeparatedIds: String): Result<List<StoryResponse>> {
         return try {
-            val response = service.getStories(commaSeparatedIds).await()
+            val response = service.getStories(commaSeparatedIds)
             getResult(response = response, onError = {
                 Result.Error(
                     IOException("Error getting stories ${response.code()} ${response.message()}")

--- a/core/src/main/java/io/plaidapp/core/dribbble/data/search/DribbbleSearchService.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/search/DribbbleSearchService.kt
@@ -17,7 +17,6 @@
 package io.plaidapp.core.dribbble.data.search
 
 import io.plaidapp.core.dribbble.data.api.model.Shot
-import kotlinx.coroutines.Deferred
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -28,12 +27,12 @@ import retrofit2.http.Query
 interface DribbbleSearchService {
 
     @GET("search")
-    fun searchDeferred(
+    suspend fun searchDeferred(
         @Query("q") query: String,
         @Query("page") page: Int?,
         @Query("s") sort: String,
         @Query("per_page") pageSize: Int
-    ): Deferred<Response<List<Shot>>>
+    ): Response<List<Shot>>
 
     companion object {
 

--- a/core/src/main/java/io/plaidapp/core/dribbble/data/search/SearchRemoteDataSource.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/search/SearchRemoteDataSource.kt
@@ -45,7 +45,7 @@ class SearchRemoteDataSource @Inject constructor(private val service: DribbbleSe
         sortOrder: SortOrder = RECENT,
         pageSize: Int = PER_PAGE_DEFAULT
     ): Result<List<Shot>> {
-        val response = service.searchDeferred(query, page, sortOrder.sort, pageSize).await()
+        val response = service.searchDeferred(query, page, sortOrder.sort, pageSize)
         if (response.isSuccessful) {
             val body = response.body()
             if (body != null) {

--- a/core/src/main/java/io/plaidapp/core/producthunt/data/ProductHuntRemoteDataSource.kt
+++ b/core/src/main/java/io/plaidapp/core/producthunt/data/ProductHuntRemoteDataSource.kt
@@ -37,7 +37,7 @@ class ProductHuntRemoteDataSource @Inject constructor(private val service: Produ
     )
 
     private suspend fun requestData(page: Int): Result<GetPostsResponse> {
-        val response = service.getPostsAsync(page).await()
+        val response = service.getPostsAsync(page)
         if (response.isSuccessful) {
             val body = response.body()
             if (body != null) {

--- a/core/src/main/java/io/plaidapp/core/producthunt/data/api/ProductHuntService.kt
+++ b/core/src/main/java/io/plaidapp/core/producthunt/data/api/ProductHuntService.kt
@@ -17,7 +17,6 @@
 package io.plaidapp.core.producthunt.data.api
 
 import io.plaidapp.core.producthunt.data.api.model.GetPostsResponse
-import kotlinx.coroutines.Deferred
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -28,7 +27,7 @@ import retrofit2.http.Query
 interface ProductHuntService {
 
     @GET("v1/posts")
-    fun getPostsAsync(@Query("days_ago") page: Int): Deferred<Response<GetPostsResponse>>
+    suspend fun getPostsAsync(@Query("days_ago") page: Int): Response<GetPostsResponse>
 
     companion object {
 

--- a/core/src/test/java/io/plaidapp/core/designernews/data/login/LoginRemoteDataSourceTest.kt
+++ b/core/src/test/java/io/plaidapp/core/designernews/data/login/LoginRemoteDataSourceTest.kt
@@ -29,7 +29,6 @@ import io.plaidapp.core.designernews.data.login.model.LoggedInUserResponse
 import io.plaidapp.core.designernews.data.login.model.UserLinks
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
 import io.plaidapp.core.designernews.errorResponseBody
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -80,9 +79,9 @@ class LoginRemoteDataSourceTest {
     fun login_successful_when_AccessTokenAndGetUserSuccessful() = runBlocking {
         // Given that all API calls are successful
         val accessTokenResponse = Response.success(accessToken)
-        whenever(service.login(any())).thenReturn(CompletableDeferred(accessTokenResponse))
+        whenever(service.login(any())).thenReturn(accessTokenResponse)
         val authUserResponse = Response.success(listOf(response))
-        whenever(service.getAuthedUser()).thenReturn(CompletableDeferred(authUserResponse))
+        whenever(service.getAuthedUser()).thenReturn(authUserResponse)
 
         // When logging in
         val result = dataSource.login("test", "test")
@@ -98,7 +97,7 @@ class LoginRemoteDataSourceTest {
             400,
             errorResponseBody
         )
-        whenever(service.login(any())).thenReturn(CompletableDeferred(failureResponse))
+        whenever(service.login(any())).thenReturn(failureResponse)
 
         // When logging in
         val result = dataSource.login("test", "test")
@@ -113,13 +112,13 @@ class LoginRemoteDataSourceTest {
     fun login_failed_whenGetUserFailed() = runBlocking {
         // Given that the access token is retrieved successfully
         val accessTokenRespone = Response.success(accessToken)
-        whenever(service.login(any())).thenReturn(CompletableDeferred(accessTokenRespone))
+        whenever(service.login(any())).thenReturn(accessTokenRespone)
         // And the get authed user failed
         val failureResponse = Response.error<List<LoggedInUserResponse>>(
             400,
             errorResponseBody
         )
-        whenever(service.getAuthedUser()).thenReturn(CompletableDeferred(failureResponse))
+        whenever(service.getAuthedUser()).thenReturn(failureResponse)
 
         // When logging in
         val result = dataSource.login("test", "test")
@@ -147,7 +146,7 @@ class LoginRemoteDataSourceTest {
     fun login_failed_whenGetUserThrowsException() = runBlocking {
         // Given that the access token is retrieved successfully
         val accessTokenRespone = Response.success(accessToken)
-        whenever(service.login(any())).thenReturn(CompletableDeferred(accessTokenRespone))
+        whenever(service.login(any())).thenReturn(accessTokenRespone)
         // And the get authed user throws an exception
         doAnswer { throw UnknownHostException() }
             .whenever(service).getAuthedUser()

--- a/core/src/test/java/io/plaidapp/core/designernews/data/stories/StoriesRemoteDataSourceTest.kt
+++ b/core/src/test/java/io/plaidapp/core/designernews/data/stories/StoriesRemoteDataSourceTest.kt
@@ -25,7 +25,6 @@ import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.errorResponseBody
 import io.plaidapp.core.designernews.storyLinks
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -102,9 +101,9 @@ class StoriesRemoteDataSourceTest {
     fun search_withSuccess() = runBlocking {
         // Given that the service responds with success
         val storyIds = stories.map { it.id.toString() }
-        whenever(service.search(query, 2)).thenReturn(CompletableDeferred(Response.success(storyIds)))
+        whenever(service.search(query, 2)).thenReturn(Response.success(storyIds))
         val commaSeparatedIds = storyIds.joinToString(",")
-        whenever(service.getStories(commaSeparatedIds)).thenReturn(CompletableDeferred(Response.success(stories)))
+        whenever(service.getStories(commaSeparatedIds)).thenReturn(Response.success(stories))
 
         // When searching for stories
         val result = dataSource.search(query, 2)
@@ -117,7 +116,7 @@ class StoriesRemoteDataSourceTest {
     fun search_withErrorScrapingResults() = runBlocking {
         // Given that the service responds with error
         val error = Response.error<List<String>>(400, errorResponseBody)
-        whenever(service.search(query, 1)).thenReturn(CompletableDeferred(error))
+        whenever(service.search(query, 1)).thenReturn(error)
 
         // When searching for stories
         val result = dataSource.search(query, 1)
@@ -144,7 +143,7 @@ class StoriesRemoteDataSourceTest {
         // Given that the service responds with error
         val storyIds = stories.joinToString(",") { it.id.toString() }
         val error = Response.error<List<StoryResponse>>(400, errorResponseBody)
-        whenever(service.getStories(storyIds)).thenReturn(CompletableDeferred(error))
+        whenever(service.getStories(storyIds)).thenReturn(error)
 
         // When searching for stories
         val result = dataSource.search(query, 1)
@@ -166,16 +165,16 @@ class StoriesRemoteDataSourceTest {
         assertTrue(result is Result.Error)
     }
 
-    private fun withStoriesSuccess(page: Int, stories: List<StoryResponse>) {
+    private suspend fun withStoriesSuccess(page: Int, stories: List<StoryResponse>) {
         val result = Response.success(stories)
-        whenever(service.getStories(page)).thenReturn(CompletableDeferred(result))
+        whenever(service.getStories(page)).thenReturn(result)
     }
 
-    private fun withStoriesError(page: Int) {
+    private suspend fun withStoriesError(page: Int) {
         val result = Response.error<List<StoryResponse>>(
             400,
             errorResponseBody
         )
-        whenever(service.getStories(page)).thenReturn(CompletableDeferred(result))
+        whenever(service.getStories(page)).thenReturn(result)
     }
 }

--- a/core/src/test/java/io/plaidapp/core/dribbble/data/search/SearchRemoteDataSourceTest.kt
+++ b/core/src/test/java/io/plaidapp/core/dribbble/data/search/SearchRemoteDataSourceTest.kt
@@ -25,7 +25,6 @@ import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.dribbble.data.errorResponseBody
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource.SortOrder
 import io.plaidapp.core.dribbble.data.shots
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -64,8 +63,7 @@ class SearchRemoteDataSourceTest {
     fun search_whenRequestFailed() = runBlocking {
         // Given that the service responds with failure
         val result = Response.error<List<Shot>>(400, errorResponseBody)
-        whenever(service.searchDeferred(query, page, defaultSortOrder, defaultResultsPerPage))
-            .thenReturn(CompletableDeferred(result))
+        whenever(service.searchDeferred(query, page, defaultSortOrder, defaultResultsPerPage)).thenReturn(result)
 
         // When performing a search
         val response = dataSource.search(query, page, SortOrder.RECENT, defaultResultsPerPage)
@@ -88,30 +86,33 @@ class SearchRemoteDataSourceTest {
 
     @Test
     fun search_defaultParams() {
-        // Given that the service responds with success when called
-        withSuccess(shots)
+        runBlocking {
+            // Given that the service responds with success when called
+            withSuccess(shots)
 
-        // When performing a search without specifying the sort or results per page
-        runBlocking { dataSource.search(query, page) }
+            // When performing a search without specifying the sort or results per page
+            dataSource.search(query, page)
 
-        // Then the default values for these params are used
-        verify(service).searchDeferred(query, page, defaultSortOrder, defaultResultsPerPage)
+            // Then the default values for these params are used
+            verify(service).searchDeferred(query, page, defaultSortOrder, defaultResultsPerPage)
+        }
     }
 
     @Test
     fun search_nonDefaultParams() {
-        // Given that the service responds with success when called
-        val popularSearchParam = ""
-        val customPerPage = 20
-        val result = Response.success(shots)
-        whenever(service.searchDeferred(query, page, popularSearchParam, customPerPage))
-            .thenReturn(CompletableDeferred(result))
+        runBlocking {
+            // Given that the service responds with success when called
+            val popularSearchParam = ""
+            val customPerPage = 20
+            val result = Response.success(shots)
+            whenever(service.searchDeferred(query, page, popularSearchParam, customPerPage)).thenReturn(result)
 
-        // When performing a search & specifying non-default sort & results per page
-        runBlocking { dataSource.search(query, page, SortOrder.POPULAR, customPerPage) }
+            // When performing a search & specifying non-default sort & results per page
+            dataSource.search(query, page, SortOrder.POPULAR, customPerPage)
 
-        // Then the supplied values for these params are used
-        verify(service).searchDeferred(query, page, popularSearchParam, customPerPage)
+            // Then the supplied values for these params are used
+            verify(service).searchDeferred(query, page, popularSearchParam, customPerPage)
+        }
     }
 
     @Test
@@ -127,9 +128,8 @@ class SearchRemoteDataSourceTest {
         assertTrue(response is Result.Error)
     }
 
-    private fun withSuccess(shots: List<Shot>?) {
+    private suspend fun withSuccess(shots: List<Shot>?) {
         val result = Response.success(shots)
-        whenever(service.searchDeferred(query, page, defaultSortOrder, defaultResultsPerPage))
-            .thenReturn(CompletableDeferred(result))
+        whenever(service.searchDeferred(query, page, defaultSortOrder, defaultResultsPerPage)).thenReturn(result)
     }
 }

--- a/core/src/test/java/io/plaidapp/core/producthunt/data/ProductHuntRemoteDataSourceTest.kt
+++ b/core/src/test/java/io/plaidapp/core/producthunt/data/ProductHuntRemoteDataSourceTest.kt
@@ -21,7 +21,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.producthunt.data.api.ProductHuntService
 import io.plaidapp.core.producthunt.data.api.model.GetPostsResponse
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -41,7 +40,7 @@ class ProductHuntRemoteDataSourceTest {
     fun loadData_whenResultSuccessful() = runBlocking {
         // Given that the service responds with success
         val result = Response.success(responseDataSuccess)
-        whenever(service.getPostsAsync(1)).thenReturn(CompletableDeferred(result))
+        whenever(service.getPostsAsync(1)).thenReturn(result)
 
         // When loading the data
         val response = dataSource.loadData(1)
@@ -58,7 +57,7 @@ class ProductHuntRemoteDataSourceTest {
             400,
             errorResponseBody
         )
-        whenever(service.getPostsAsync(1)).thenReturn(CompletableDeferred(result))
+        whenever(service.getPostsAsync(1)).thenReturn(result)
 
         // When loading posts
         val response = dataSource.loadData(1)

--- a/core/src/test/java/io/plaidapp/core/producthunt/data/api/FakeProductHuntService.kt
+++ b/core/src/test/java/io/plaidapp/core/producthunt/data/api/FakeProductHuntService.kt
@@ -17,8 +17,6 @@
 package io.plaidapp.core.producthunt.data.api
 
 import io.plaidapp.core.producthunt.data.api.model.GetPostsResponse
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import retrofit2.Response
 
 /**
@@ -26,8 +24,8 @@ import retrofit2.Response
  */
 abstract class FakeProductHuntService : ProductHuntService {
 
-    override fun getPostsAsync(page: Int): Deferred<Response<GetPostsResponse>> {
-        return CompletableDeferred(getPostsResponse())
+    override suspend fun getPostsAsync(page: Int): Response<GetPostsResponse> {
+        return getPostsResponse()
     }
 
     abstract fun getPostsResponse(): Response<GetPostsResponse>

--- a/designernews/src/main/java/io/plaidapp/designernews/data/api/DesignerNewsService.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/api/DesignerNewsService.kt
@@ -17,15 +17,12 @@
 package io.plaidapp.designernews.data.api
 
 import io.plaidapp.core.data.api.EnvelopePayload
-import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.designernews.data.votes.model.UpvoteCommentRequest
 import io.plaidapp.designernews.data.votes.model.UpvoteStoryRequest
 import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.designernews.data.comments.model.NewCommentRequest
 import io.plaidapp.designernews.data.comments.model.PostCommentResponse
-import kotlinx.coroutines.Deferred
-import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -43,27 +40,23 @@ interface DesignerNewsService {
 
     @EnvelopePayload("users")
     @GET("api/v2/users/{ids}")
-    fun getUsers(@Path("ids") userids: String): Deferred<Response<List<User>>>
-
-    @EnvelopePayload("story")
-    @POST("api/v2/stories/{id}/upvote")
-    fun upvoteStory(@Path("id") storyId: Long): Call<Story>
+    suspend fun getUsers(@Path("ids") userids: String): Response<List<User>>
 
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/upvotes")
-    fun upvoteStoryV2(@Body request: UpvoteStoryRequest): Deferred<Response<Unit>>
+    suspend fun upvoteStory(@Body request: UpvoteStoryRequest): Response<Unit>
 
     @EnvelopePayload("comments")
     @GET("api/v2/comments/{ids}")
-    fun getComments(@Path("ids") commentIds: String): Deferred<Response<List<CommentResponse>>>
+    suspend fun getComments(@Path("ids") commentIds: String): Response<List<CommentResponse>>
 
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/comments")
-    fun comment(@Body comment: NewCommentRequest): Deferred<Response<PostCommentResponse>>
+    suspend fun comment(@Body comment: NewCommentRequest): Response<PostCommentResponse>
 
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/comment_upvotes")
-    fun upvoteComment(@Body request: UpvoteCommentRequest): Deferred<Response<Unit>>
+    suspend fun upvoteComment(@Body request: UpvoteCommentRequest): Response<Unit>
 
     companion object {
         const val ENDPOINT = "https://www.designernews.co/"

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
@@ -38,7 +38,7 @@ class CommentsRemoteDataSource(private val service: DesignerNewsService) {
 
     private suspend fun requestGetComments(ids: List<Long>): Result<List<CommentResponse>> {
         val requestIds = ids.joinToString(",")
-        val response = service.getComments(requestIds).await()
+        val response = service.getComments(requestIds)
         if (response.isSuccessful) {
             val body = response.body()
             if (body != null) {
@@ -82,7 +82,7 @@ class CommentsRemoteDataSource(private val service: DesignerNewsService) {
             story = storyId?.toString(),
             user = userId.toString()
         )
-        val response = service.comment(request).await()
+        val response = service.comment(request)
         if (response.isSuccessful) {
             val body = response.body()
             if (body != null && !body.comments.isEmpty()) {

--- a/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRemoteDataSource.kt
@@ -36,7 +36,7 @@ class UserRemoteDataSource @Inject constructor(private val service: DesignerNews
     private suspend fun requestGetUsers(userIds: List<Long>): Result<List<User>> {
         val requestIds = userIds.joinToString(",")
 
-        val response = service.getUsers(requestIds).await()
+        val response = service.getUsers(requestIds)
         if (response.isSuccessful) {
             val body = response.body()
             if (body != null) {

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
@@ -36,7 +36,7 @@ class VotesRemoteDataSource @Inject constructor(private val service: DesignerNew
 
     private suspend fun requestUpvoteStory(storyId: Long, userId: Long): Result<Unit> {
         val request = UpvoteStoryRequest(storyId, userId)
-        val response = service.upvoteStoryV2(request).await()
+        val response = service.upvoteStory(request)
         return if (response.isSuccessful) {
             Result.Success(Unit)
         } else {
@@ -55,7 +55,7 @@ class VotesRemoteDataSource @Inject constructor(private val service: DesignerNew
 
     private suspend fun requestUpvoteComment(commentId: Long, userId: Long): Result<Unit> {
         val request = UpvoteCommentRequest(commentId, userId)
-        val response = service.upvoteComment(request).await()
+        val response = service.upvoteComment(request)
         return if (response.isSuccessful) {
             Result.Success(Unit)
         } else {

--- a/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
@@ -27,7 +27,6 @@ import io.plaidapp.designernews.data.comments.model.PostCommentResponse
 import io.plaidapp.designernews.errorResponseBody
 import io.plaidapp.designernews.repliesResponses
 import io.plaidapp.designernews.replyResponse1
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -50,7 +49,7 @@ class CommentsRemoteDataSourceTest {
     fun getComments_whenRequestSuccessful() = runBlocking {
         // Given that the service responds with success
         val result = Response.success(repliesResponses)
-        whenever(service.getComments("1")).thenReturn(CompletableDeferred(result))
+        whenever(service.getComments("1")).thenReturn(result)
 
         // When getting the list of comments
         val response = dataSource.getComments(listOf(1L))
@@ -64,7 +63,7 @@ class CommentsRemoteDataSourceTest {
     fun getComments_forMultipleComments() = runBlocking {
         // Given that the service responds with success for specific ids
         val result = Response.success(repliesResponses)
-        whenever(service.getComments("11,12")).thenReturn(CompletableDeferred(result))
+        whenever(service.getComments("11,12")).thenReturn(result)
 
         // When getting the list of comments for specific list of ids
         val response = dataSource.getComments(listOf(11L, 12L))
@@ -81,7 +80,7 @@ class CommentsRemoteDataSourceTest {
             400,
             errorResponseBody
         )
-        whenever(service.getComments("1")).thenReturn(CompletableDeferred(result))
+        whenever(service.getComments("1")).thenReturn(result)
 
         // When getting the list of comments
         val response = dataSource.getComments(listOf(1L))
@@ -94,7 +93,7 @@ class CommentsRemoteDataSourceTest {
     fun getComments_whenResponseEmpty() = runBlocking {
         // Given that the service responds with success but with an empty response
         val result = Response.success<List<CommentResponse>>(null)
-        whenever(service.getComments("1")).thenReturn(CompletableDeferred(result))
+        whenever(service.getComments("1")).thenReturn(result)
 
         // When getting the list of comments
         val response = dataSource.getComments(listOf(1L))
@@ -147,7 +146,7 @@ class CommentsRemoteDataSourceTest {
             )
         )
         val request = NewCommentRequest(body, "11", null, "111")
-        whenever(service.comment(request)).thenReturn(CompletableDeferred(response))
+        whenever(service.comment(request)).thenReturn(response)
 
         // When adding a comment
         val result = dataSource.comment(body, 11L, null, 111L)
@@ -163,7 +162,7 @@ class CommentsRemoteDataSourceTest {
             PostCommentResponse(listOf(replyResponse1))
         )
         val request = NewCommentRequest(body, "11", null, "111")
-        whenever(service.comment(request)).thenReturn(CompletableDeferred(response))
+        whenever(service.comment(request)).thenReturn(response)
 
         // When adding a comment
         val result = dataSource.comment(body, 11L, null, 111L)

--- a/designernews/src/test/java/io/plaidapp/designernews/data/users/UserRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/users/UserRemoteDataSourceTest.kt
@@ -23,7 +23,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.designernews.data.api.DesignerNewsService
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType
 import okhttp3.ResponseBody
@@ -96,16 +95,16 @@ class UserRemoteDataSourceTest {
         assertTrue(result is Result.Error)
     }
 
-    private fun withUsersSuccess(ids: String, users: List<User>) {
+    private suspend fun withUsersSuccess(ids: String, users: List<User>) {
         val result = Response.success(users)
-        whenever(service.getUsers(ids)).thenReturn(CompletableDeferred(result))
+        whenever(service.getUsers(ids)).thenReturn(result)
     }
 
-    private fun withUsersError(ids: String) {
+    private suspend fun withUsersError(ids: String) {
         val result = Response.error<List<User>>(
             400,
             errorResponseBody
         )
-        whenever(service.getUsers(ids)).thenReturn(CompletableDeferred(result))
+        whenever(service.getUsers(ids)).thenReturn(result)
     }
 }

--- a/designernews/src/test/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSourceTest.kt
@@ -23,7 +23,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.errorResponseBody
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -47,7 +46,7 @@ class VotesRemoteDataSourceTest {
     fun upvoteStory_whenRequestSuccessful() = runBlocking {
         // Given that the service responds with success
         val response = Response.success(Unit)
-        whenever(service.upvoteStoryV2(any())).thenReturn(CompletableDeferred(response))
+        whenever(service.upvoteStory(any())).thenReturn(response)
 
         // When upvoting a story
         val result = dataSource.upvoteStory(storyId, userId)
@@ -60,7 +59,7 @@ class VotesRemoteDataSourceTest {
     fun upvoteStory_whenRequestFailed() = runBlocking {
         // Given that the service responds with error
         val response = Response.error<Unit>(404, errorResponseBody)
-        whenever(service.upvoteStoryV2(any())).thenReturn(CompletableDeferred(response))
+        whenever(service.upvoteStory(any())).thenReturn(response)
 
         // When upvoting a story
         val result = dataSource.upvoteStory(storyId, userId)
@@ -73,7 +72,7 @@ class VotesRemoteDataSourceTest {
     fun upvoteStory_whenExceptionThrown() = runBlocking {
         // Given that the service trows an exception
         doAnswer { throw UnknownHostException() }
-            .whenever(service).upvoteStoryV2(any())
+            .whenever(service).upvoteStory(any())
 
         // When upvoting a story
         val result = dataSource.upvoteStory(storyId, userId)
@@ -86,7 +85,7 @@ class VotesRemoteDataSourceTest {
     fun upvoteComment_whenRequestSuccessful() = runBlocking {
         // Given that the service responds with success
         val response = Response.success(Unit)
-        whenever(service.upvoteComment(any())).thenReturn(CompletableDeferred(response))
+        whenever(service.upvoteComment(any())).thenReturn(response)
 
         // When upvoting a comment
         val result = dataSource.upvoteComment(storyId, userId)
@@ -99,7 +98,7 @@ class VotesRemoteDataSourceTest {
     fun upvoteComment_whenRequestFailed() = runBlocking {
         // Given that the service responds with error
         val response = Response.error<Unit>(404, errorResponseBody)
-        whenever(service.upvoteComment(any())).thenReturn(CompletableDeferred(response))
+        whenever(service.upvoteComment(any())).thenReturn(response)
 
         // When upvoting a comment
         val result = dataSource.upvoteComment(storyId, userId)

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
@@ -37,7 +37,6 @@ import io.plaidapp.designernews.reply1NoUser
 import io.plaidapp.designernews.replyResponse1
 import io.plaidapp.designernews.user1
 import io.plaidapp.designernews.user2
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -82,7 +81,7 @@ class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
             400,
             errorResponseBody
         )
-        whenever(service.getComments("11")).thenReturn(CompletableDeferred(apiResult))
+        whenever(service.getComments("11")).thenReturn(apiResult)
 
         // When getting the comments
         val result = repository(listOf(11L))
@@ -124,8 +123,7 @@ class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
             400,
             errorResponseBody
         )
-        whenever(service.getComments("11,12"))
-            .thenReturn(CompletableDeferred(resultChildrenError))
+        whenever(service.getComments("11,12")).thenReturn(resultChildrenError)
         // Given that the user request responds with success
         withUsers(listOf(user2), "222")
 
@@ -152,7 +150,7 @@ class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
             errorResponseBody
         )
         whenever(service.getUsers("111"))
-            .thenReturn(CompletableDeferred(userError))
+            .thenReturn(userError)
 
         // When getting the comments from the repository
         val result = repository(listOf(11L))
@@ -167,16 +165,16 @@ class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
     // Given that the users request responds with success
     private fun withUsers(users: List<User>, ids: String) = runBlocking {
         val userResult = Response.success(users)
-        whenever(service.getUsers(ids)).thenReturn(CompletableDeferred(userResult))
+        whenever(service.getUsers(ids)).thenReturn(userResult)
     }
 
-    private fun withComments(commentResponse: CommentResponse, ids: String) {
+    private suspend fun withComments(commentResponse: CommentResponse, ids: String) {
         val resultParent = Response.success(listOf(commentResponse))
-        whenever(service.getComments(ids)).thenReturn(CompletableDeferred(resultParent))
+        whenever(service.getComments(ids)).thenReturn(resultParent)
     }
 
-    private fun withComments(commentResponse: List<CommentResponse>, ids: String) {
+    private suspend fun withComments(commentResponse: List<CommentResponse>, ids: String) {
         val resultParent = Response.success(commentResponse)
-        whenever(service.getComments(ids)).thenReturn(CompletableDeferred(resultParent))
+        whenever(service.getComments(ids)).thenReturn(resultParent)
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 06 13:11:31 CET 2019
+#Wed Jun 12 10:15:29 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds new Retrofit 2.6.0 `suspend` modifier to Retrofit interfaces.

No need to call `.await()` on those functions anymore because it's a `suspend` function instead of it returning a `Deferred` object.

## :green_heart: How did you test it?
Unit tests run locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
