### PR TITLE
Stop adding git SHA to BuildConfig.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,6 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
         resConfig 'en'
-        buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
         manifestPlaceholders += [
                 crashlyticsEnabled: false
         ]

--- a/build.gradle
+++ b/build.gradle
@@ -75,8 +75,7 @@ plugins {
 }
 
 ext {
-    // query git for the SHA, Tag and commit count. Use these to automate versioning.
-    gitSha = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
+    // query git for the commit count to automate versioning.
     gitCommitCount = 100 +
             Integer.parseInt('git rev-list --count HEAD'.execute([], project.rootDir).text.trim())
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Stop adding git SHA to the generated `BuildConfig` class.


## :bulb: Motivation and Context
It wasn't used anywhere, the idea was to potentially add this to crash reports etc but was never implemented. Changing the `BuildConfig` class on every build degrades build performance (see #718).

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
none

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
