### PR TITLE
Draw edge-to-edge

### DIFF
--- a/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
@@ -16,14 +16,15 @@
 
 package io.plaidapp.about.ui.adapter
 
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import io.plaidapp.about.R
+import io.plaidapp.about.databinding.AboutIconBinding
+import io.plaidapp.about.databinding.AboutLibsBinding
+import io.plaidapp.about.databinding.AboutPlaidBinding
 import io.plaidapp.about.ui.model.AboutUiModel
 import io.plaidapp.core.util.HtmlUtils
-import io.plaidapp.core.util.inflateView
 import java.security.InvalidParameterException
 
 /**
@@ -62,32 +63,34 @@ internal class AboutPagerAdapter(private val uiModel: AboutUiModel) :
         // do nothing
     }
 
-    private fun getAboutIconPage(parent: ViewGroup): View {
-        return aboutIcon ?: parent.inflateView(R.layout.about_icon).apply {
-            findViewById<TextView>(R.id.icon_description).apply {
-                HtmlUtils.setTextWithNiceLinks(this, uiModel.iconAboutText)
+    private fun getAboutAppPage(parent: ViewGroup): View {
+        if (aboutPlaid == null) {
+            AboutPlaidBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
+                HtmlUtils.setTextWithNiceLinks(aboutDescription, uiModel.appAboutText)
+                aboutPlaid = root
             }
-            aboutIcon = this
         }
+        return aboutPlaid!!
     }
 
-    private fun getAboutAppPage(parent: ViewGroup): View {
-        return aboutPlaid ?: parent.inflateView(R.layout.about_plaid)
-            .apply {
-                findViewById<TextView>(R.id.about_description).apply {
-                    HtmlUtils.setTextWithNiceLinks(this, uiModel.appAboutText)
-                }
-                aboutPlaid = this
+    private fun getAboutIconPage(parent: ViewGroup): View {
+        if (aboutIcon == null) {
+            AboutIconBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
+                HtmlUtils.setTextWithNiceLinks(iconDescription, uiModel.iconAboutText)
+                aboutIcon = root
             }
+        }
+        return aboutIcon!!
     }
 
     private fun getAboutLibsPage(parent: ViewGroup): View {
-        return aboutLibs ?: parent.inflateView(R.layout.about_libs).apply {
-            findViewById<RecyclerView>(R.id.libs_list).apply {
-                adapter = LibraryAdapter(uiModel.librariesUiModel)
+        if (aboutLibs == null) {
+            AboutLibsBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
+                libsList.adapter = LibraryAdapter(uiModel.librariesUiModel)
+                aboutLibs = root
             }
-            aboutLibs = this
         }
+        return aboutLibs!!
     }
 
     class AboutViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)

--- a/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
@@ -31,11 +31,11 @@ import java.security.InvalidParameterException
  * Adapter creating and holding on to pages displayed within [io.plaidapp.about.ui.AboutActivity].
  */
 internal class AboutPagerAdapter(private val uiModel: AboutUiModel) :
-        RecyclerView.Adapter<AboutPagerAdapter.AboutViewHolder>() {
+    RecyclerView.Adapter<AboutPagerAdapter.AboutViewHolder>() {
 
-    private var aboutPlaid: View? = null
-    private var aboutIcon: View? = null
-    private var aboutLibs: View? = null
+    private var aboutPlaidBinding: AboutPlaidBinding? = null
+    private var aboutIconBinding: AboutIconBinding? = null
+    private var aboutLibsBinding: AboutLibsBinding? = null
 
     override fun getItemViewType(position: Int): Int {
         return when (position) {
@@ -47,50 +47,56 @@ internal class AboutPagerAdapter(private val uiModel: AboutUiModel) :
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AboutViewHolder {
-        return when (viewType) {
-            0 -> AboutViewHolder(getAboutAppPage(parent))
-            1 -> AboutViewHolder(getAboutIconPage(parent))
-            2 -> AboutViewHolder(getAboutLibsPage(parent))
-            else -> throw InvalidParameterException()
-        }
+        return AboutViewHolder(
+            when (viewType) {
+                0 -> getAboutAppPage(parent)
+                1 -> getAboutIconPage(parent)
+                2 -> getAboutLibsPage(parent)
+                else -> throw InvalidParameterException()
+            }
+        )
     }
 
-    override fun getItemCount(): Int {
-        return 3
-    }
+    override fun getItemCount() = 3
 
     override fun onBindViewHolder(holder: AboutViewHolder, position: Int) {
         // do nothing
     }
 
     private fun getAboutAppPage(parent: ViewGroup): View {
-        if (aboutPlaid == null) {
-            AboutPlaidBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
-                HtmlUtils.setTextWithNiceLinks(aboutDescription, uiModel.appAboutText)
-                aboutPlaid = root
-            }
+        val binding = aboutPlaidBinding ?: AboutPlaidBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        ).apply {
+            HtmlUtils.setTextWithNiceLinks(aboutDescription, uiModel.appAboutText)
+            aboutPlaidBinding = this
         }
-        return aboutPlaid!!
+        return binding.root
     }
 
     private fun getAboutIconPage(parent: ViewGroup): View {
-        if (aboutIcon == null) {
-            AboutIconBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
-                HtmlUtils.setTextWithNiceLinks(iconDescription, uiModel.iconAboutText)
-                aboutIcon = root
-            }
+        val binding = aboutIconBinding ?: AboutIconBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        ).apply {
+            HtmlUtils.setTextWithNiceLinks(iconDescription, uiModel.iconAboutText)
+            aboutIconBinding = this
         }
-        return aboutIcon!!
+        return binding.root
     }
 
     private fun getAboutLibsPage(parent: ViewGroup): View {
-        if (aboutLibs == null) {
-            AboutLibsBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
-                libsList.adapter = LibraryAdapter(uiModel.librariesUiModel)
-                aboutLibs = root
-            }
+        val binding = aboutLibsBinding ?: AboutLibsBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        ).apply {
+            libsList.adapter = LibraryAdapter(uiModel.librariesUiModel)
+            aboutLibsBinding = this
         }
-        return aboutLibs!!
+        return binding.root
     }
 
     class AboutViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)

--- a/about/src/main/res/layout/about_icon.xml
+++ b/about/src/main/res/layout/about_icon.xml
@@ -16,43 +16,51 @@
   ~
   -->
 
-<ScrollView
-    xmlns:tools="http://schemas.android.com/tools"
+<layout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:nestedScrollingEnabled="true"
-    tools:showIn="@layout/activity_about">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
+    <ScrollView
+        android:id="@+id/root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:background="?attr/colorSurface"
-        android:elevation="@dimen/z_card">
+        android:nestedScrollingEnabled="true"
+        android:clipToPadding="false"
+        app:paddingBottomSystemWindowInsets="@{true}"
+        app:paddingRightSystemWindowInsets="@{true}"
+        tools:showIn="@layout/activity_about">
 
-        <ImageView
-            android:id="@+id/icon"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="@dimen/about_header_height"
-            android:layout_marginTop="@dimen/spacing_large"
-            android:padding="@dimen/about_icon_padding"
-            android:scaleType="centerInside"
-            android:src="@drawable/ic_launcher_512px" />
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:background="?attr/colorSurface"
+            android:elevation="@dimen/z_card">
 
-        <io.plaidapp.core.ui.widget.BaselineGridTextView
-            android:id="@+id/icon_description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="top|center_horizontal"
-            android:paddingStart="@dimen/padding_normal"
-            android:paddingTop="24dp"
-            android:paddingEnd="@dimen/padding_normal"
-            android:paddingBottom="@dimen/spacing_large"
-            android:textAppearance="@style/TextAppearance.About"
-            android:textColorHighlight="?attr/colorPrimary"
-            android:textColorLink="@color/plaid_links" />
+            <ImageView
+                android:id="@+id/icon"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/about_header_height"
+                android:layout_marginTop="@dimen/spacing_large"
+                android:padding="@dimen/about_icon_padding"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_launcher_512px" />
 
-    </LinearLayout>
+            <io.plaidapp.core.ui.widget.BaselineGridTextView
+                android:id="@+id/icon_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top|center_horizontal"
+                android:paddingStart="@dimen/padding_normal"
+                android:paddingTop="24dp"
+                android:paddingEnd="@dimen/padding_normal"
+                android:paddingBottom="@dimen/spacing_large"
+                android:textAppearance="@style/TextAppearance.About"
+                android:textColorHighlight="?attr/colorPrimary"
+                android:textColorLink="@color/plaid_links" />
 
-</ScrollView>
+        </LinearLayout>
+
+    </ScrollView>
+</layout>

--- a/about/src/main/res/layout/about_icon.xml
+++ b/about/src/main/res/layout/about_icon.xml
@@ -45,7 +45,7 @@
                 android:layout_marginTop="@dimen/spacing_large"
                 android:padding="@dimen/about_icon_padding"
                 android:scaleType="centerInside"
-                android:src="@drawable/ic_launcher_512px" />
+                app:srcCompat="@drawable/ic_launcher_512px" />
 
             <io.plaidapp.core.ui.widget.BaselineGridTextView
                 android:id="@+id/icon_description"

--- a/about/src/main/res/layout/about_libs.xml
+++ b/about/src/main/res/layout/about_libs.xml
@@ -16,30 +16,36 @@
   ~
   -->
 
-<FrameLayout
+<layout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:showIn="@layout/activity_about">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- we use a parallel view for the background rather than just setting a background on the
-         recycler view for a nicer return transition. i.e. we want the background to fade and the
-         list to slide out separately -->
-    <View
-        android:id="@+id/libs_list_background"
+    <FrameLayout
+        android:id="@+id/root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="?android:colorBackground" />
+        tools:showIn="@layout/activity_about">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/libs_list"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/spacing_normal"
-        android:clipToPadding="false"
-        android:scrollbars="vertical"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+        <!-- we use a parallel view for the background rather than just setting a background on the
+             recycler view for a nicer return transition. i.e. we want the background to fade and the
+             list to slide out separately -->
+        <View
+            android:id="@+id/libs_list_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:colorBackground" />
 
-</FrameLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/libs_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/spacing_normal"
+            android:clipToPadding="false"
+            android:scrollbars="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:paddingBottomSystemWindowInsets="@{true}"
+            app:paddingRightSystemWindowInsets="@{true}" />
+
+    </FrameLayout>
+</layout>

--- a/about/src/main/res/layout/about_libs.xml
+++ b/about/src/main/res/layout/about_libs.xml
@@ -39,10 +39,11 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/libs_list"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:paddingBottom="@dimen/spacing_normal"
             android:clipToPadding="false"
             android:scrollbars="vertical"
+            app:hasFixedSize="@{true}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:paddingBottomSystemWindowInsets="@{true}"
             app:paddingRightSystemWindowInsets="@{true}" />

--- a/about/src/main/res/layout/about_plaid.xml
+++ b/about/src/main/res/layout/about_plaid.xml
@@ -16,42 +16,49 @@
   ~
   -->
 
-<ScrollView
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<layout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:nestedScrollingEnabled="true"
-    tools:showIn="@layout/activity_about">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <LinearLayout
+    <ScrollView
+        android:id="@+id/root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:nestedScrollingEnabled="true"
+        android:clipToPadding="false"
+        app:paddingBottomSystemWindowInsets="@{true}"
+        app:paddingRightSystemWindowInsets="@{true}"
+        tools:showIn="@layout/activity_about">
 
-        <io.plaidapp.about.ui.widget.CutoutTextView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="@dimen/about_header_height"
-            android:text="@string/app_name"
-            android:fontFamily="@font/roboto_mono"
-            app:foregroundColor="?attr/colorPrimary" />
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-        <io.plaidapp.core.ui.widget.BaselineGridTextView
-            android:id="@+id/about_description"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:background="?attr/colorSurface"
-            android:breakStrategy="simple"
-            android:paddingStart="@dimen/padding_normal"
-            android:paddingTop="@dimen/padding_normal"
-            android:paddingEnd="@dimen/padding_normal"
-            android:paddingBottom="@dimen/spacing_large"
-            android:textAppearance="@style/TextAppearance.About"
-            android:textColorHighlight="?attr/colorPrimary"
-            android:textColorLink="@color/plaid_links" />
+            <io.plaidapp.about.ui.widget.CutoutTextView
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/about_header_height"
+                android:text="@string/app_name"
+                android:fontFamily="@font/roboto_mono"
+                app:foregroundColor="?attr/colorPrimary" />
 
-    </LinearLayout>
+            <io.plaidapp.core.ui.widget.BaselineGridTextView
+                android:id="@+id/about_description"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:background="?attr/colorSurface"
+                android:breakStrategy="simple"
+                android:paddingStart="@dimen/padding_normal"
+                android:paddingTop="@dimen/padding_normal"
+                android:paddingEnd="@dimen/padding_normal"
+                android:paddingBottom="@dimen/spacing_large"
+                android:textAppearance="@style/TextAppearance.About"
+                android:textColorHighlight="?attr/colorPrimary"
+                android:textColorLink="@color/plaid_links" />
 
-</ScrollView>
+        </LinearLayout>
+
+    </ScrollView>
+</layout>

--- a/about/src/main/res/layout/activity_about.xml
+++ b/about/src/main/res/layout/activity_about.xml
@@ -16,31 +16,35 @@
   ~
   -->
 
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
-            android:id="@+id/draggable_frame"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:dragDismissDistance="@dimen/drag_dismiss_distance"
-            app:dragDismissScale="0.95"
-            tools:context=".ui.AboutActivity">
+        android:id="@+id/draggable_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:dragDismissDistance="@dimen/drag_dismiss_distance"
+        app:dragDismissScale="0.95"
+        app:layoutFullscreen="@{true}"
+        app:paddingTopSystemWindowInsets="@{true}"
+        android:clipToPadding="false"
+        tools:context=".ui.AboutActivity">
 
         <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/pager"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
+            android:id="@+id/pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
         <io.plaidapp.about.ui.widget.InkPageIndicator
-                android:id="@+id/indicator"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="top|center_horizontal"
-                android:layout_marginTop="@dimen/padding_normal"
-                app:pageIndicatorColor="@color/page_indicators"
-                app:currentPageIndicatorColor="@color/page_indicator_selected"/>
+            android:id="@+id/indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|center_horizontal"
+            android:layout_marginTop="@dimen/padding_normal"
+            app:pageIndicatorColor="@color/page_indicators"
+            app:currentPageIndicatorColor="@color/page_indicator_selected" />
 
     </io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout>
 

--- a/core/src/main/java/io/plaidapp/core/util/BindingAdapters.kt
+++ b/core/src/main/java/io/plaidapp/core/util/BindingAdapters.kt
@@ -88,9 +88,9 @@ fun bindImage(
 }
 
 @BindingAdapter("layoutFullscreen")
-fun bindLayoutFullscreen(view: View, fullscreen: Boolean) {
-    if (fullscreen) {
-        view.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+fun View.bindLayoutFullscreen(previousFullscreen: Boolean, fullscreen: Boolean) {
+    if (previousFullscreen != fullscreen && fullscreen) {
+        systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
             View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
             View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
     }
@@ -103,14 +103,25 @@ fun bindLayoutFullscreen(view: View, fullscreen: Boolean) {
     "paddingBottomSystemWindowInsets",
     requireAll = false
 )
-fun applySystemWindowInsetsPadding(
-    view: View,
+fun View.applySystemWindowInsetsPadding(
+    previousApplyLeft: Boolean,
+    previousApplyTop: Boolean,
+    previousApplyRight: Boolean,
+    previousApplyBottom: Boolean,
     applyLeft: Boolean,
     applyTop: Boolean,
     applyRight: Boolean,
     applyBottom: Boolean
 ) {
-    view.doOnApplyWindowInsets { view, insets, padding, _ ->
+    if (previousApplyLeft == applyLeft &&
+        previousApplyTop == applyTop &&
+        previousApplyRight == applyRight &&
+        previousApplyBottom == applyBottom
+    ) {
+        return
+    }
+
+    doOnApplyWindowInsets { view, insets, padding, _ ->
         val left = if (applyLeft) insets.systemWindowInsetLeft else 0
         val top = if (applyTop) insets.systemWindowInsetTop else 0
         val right = if (applyRight) insets.systemWindowInsetRight else 0
@@ -132,14 +143,25 @@ fun applySystemWindowInsetsPadding(
     "marginBottomSystemWindowInsets",
     requireAll = false
 )
-fun applySystemWindowInsetsMargin(
-    view: View,
+fun View.applySystemWindowInsetsMargin(
+    previousApplyLeft: Boolean,
+    previousApplyTop: Boolean,
+    previousApplyRight: Boolean,
+    previousApplyBottom: Boolean,
     applyLeft: Boolean,
     applyTop: Boolean,
     applyRight: Boolean,
     applyBottom: Boolean
 ) {
-    view.doOnApplyWindowInsets { view, insets, _, margin ->
+    if (previousApplyLeft == applyLeft &&
+        previousApplyTop == applyTop &&
+        previousApplyRight == applyRight &&
+        previousApplyBottom == applyBottom
+    ) {
+        return
+    }
+
+    doOnApplyWindowInsets { view, insets, _, margin ->
         val left = if (applyLeft) insets.systemWindowInsetLeft else 0
         val top = if (applyTop) insets.systemWindowInsetTop else 0
         val right = if (applyRight) insets.systemWindowInsetRight else 0
@@ -154,14 +176,14 @@ fun applySystemWindowInsetsMargin(
     }
 }
 
-fun View.doOnApplyWindowInsets(f: (View, WindowInsets, InitialPadding, InitialMargin) -> Unit) {
+fun View.doOnApplyWindowInsets(block: (View, WindowInsets, InitialPadding, InitialMargin) -> Unit) {
     // Create a snapshot of the view's padding & margin states
     val initialPadding = recordInitialPaddingForView(this)
     val initialMargin = recordInitialMarginForView(this)
     // Set an actual OnApplyWindowInsetsListener which proxies to the given
     // lambda, also passing in the original padding & margin states
     setOnApplyWindowInsetsListener { v, insets ->
-        f(v, insets, initialPadding, initialMargin)
+        block(v, insets, initialPadding, initialMargin)
         // Always return the insets, so that children can also use them
         insets
     }

--- a/core/src/main/res/values-v29/colors.xml
+++ b/core/src/main/res/values-v29/colors.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2019 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<resources>
+
+    <!-- common colours -->
+    <color name="nav_bar">@android:color/transparent</color>
+
+</resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -73,8 +73,6 @@
     <color name="designer_news_link_highlight">#b303a9f4</color>
     <color name="designer_news_story_comment_background">@android:color/transparent</color>
 
-    <color name="designer_news_super_dark">#000133</color>
-
     <!-- product hunt-->
     <color name="product_hunt">#ffff9800</color> <!--orange 500 -->
 

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -34,6 +34,7 @@
     <color name="ripple_dark">@color/mid_grey</color>
     <color name="background_light">#fafafa</color> <!-- grey 50 -->
     <color name="background_dark">#ff333333</color>
+    <color name="nav_bar">@color/immersive_bars</color> <!-- overridden on v29+ -->
     <color name="immersive_bars">#99000000</color>
     <color name="light_immersive_bars">#b3eeeeee</color> <!-- 70% grey 200 -->
     <color name="light_status_bar">@color/immersive_bars</color> <!-- overridden on v23+ -->

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -63,6 +63,7 @@
         <!-- using a semi-transparent window background for the drag-back gesture -->
         <item name="android:windowBackground">@color/scrim</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:navigationBarColor">@color/nav_bar</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowIsTranslucent">true</item>

--- a/core/src/main/res/values/styles.xml
+++ b/core/src/main/res/values/styles.xml
@@ -49,7 +49,7 @@
     <style name="Plaid.Home">
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@color/immersive_bars</item>
-        <item name="android:navigationBarColor">@color/immersive_bars</item>
+        <item name="android:navigationBarColor">@color/nav_bar</item>
         <item name="android:windowActionBarOverlay">true</item>
         <item name="android:windowActionModeOverlay">true</item>
         <item name="android:windowContentOverlay">@null</item>

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryActivity.java
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryActivity.java
@@ -194,15 +194,22 @@ public class StoryActivity extends AppCompatActivity {
                 View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
                 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
         final int stableListPaddingBottom = commentsList.getPaddingBottom();
+        final int stableListPaddingRight = commentsList.getPaddingRight();
+        final int stableFabMarginBottom = ((MarginLayoutParams) fab.getLayoutParams()).bottomMargin;
+        final int stableFabMarginRight = ((MarginLayoutParams) fab.getLayoutParams()).bottomMargin;
         draggableFrame.setOnApplyWindowInsetsListener((v, insets) -> {
-            final MarginLayoutParams lp = (MarginLayoutParams) v.getLayoutParams();
-            lp.topMargin = insets.getSystemWindowInsetTop();
-            v.setLayoutParams(lp);
+            final MarginLayoutParams listLp = (MarginLayoutParams) v.getLayoutParams();
+            listLp.topMargin = insets.getSystemWindowInsetTop();
+            v.setLayoutParams(listLp);
             commentsList.setPadding(
                     commentsList.getPaddingLeft(),
                     commentsList.getPaddingTop(),
-                    commentsList.getPaddingRight(),
+                    stableListPaddingRight + insets.getSystemWindowInsetRight(),
                     stableListPaddingBottom + insets.getSystemWindowInsetBottom());
+            final MarginLayoutParams fabLp = (MarginLayoutParams) fab.getLayoutParams();
+            fabLp.rightMargin = stableFabMarginRight + insets.getSystemWindowInsetRight();
+            fabLp.bottomMargin = stableFabMarginBottom + insets.getSystemWindowInsetBottom();
+            fab.setLayoutParams(fabLp);
             return insets;
         });
 

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryActivity.java
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryActivity.java
@@ -87,6 +87,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static android.view.ViewGroup.MarginLayoutParams;
 import static com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade;
 import static io.plaidapp.core.util.AnimUtils.getFastOutLinearInInterpolator;
 import static io.plaidapp.core.util.AnimUtils.getFastOutSlowInInterpolator;
@@ -120,9 +121,12 @@ public class StoryActivity extends AppCompatActivity {
 
     private Story story;
 
-    @Inject StoryViewModel viewModel;
-    @Inject LoginRepository loginRepository;
-    @Inject Markdown markdown;
+    @Inject
+    StoryViewModel viewModel;
+    @Inject
+    LoginRepository loginRepository;
+    @Inject
+    Markdown markdown;
 
     private CustomTabActivityHelper customTab;
 
@@ -185,6 +189,22 @@ public class StoryActivity extends AppCompatActivity {
         commentsAdapter = new DesignerNewsCommentsAdapter(
                 header, new ArrayList<>(0), enterCommentView);
         commentsList.setAdapter(commentsAdapter);
+
+        draggableFrame.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
+        final int stableListPaddingBottom = commentsList.getPaddingBottom();
+        draggableFrame.setOnApplyWindowInsetsListener((v, insets) -> {
+            final MarginLayoutParams lp = (MarginLayoutParams) v.getLayoutParams();
+            lp.topMargin = insets.getSystemWindowInsetTop();
+            v.setLayoutParams(lp);
+            commentsList.setPadding(
+                    commentsList.getPaddingLeft(),
+                    commentsList.getPaddingTop(),
+                    commentsList.getPaddingRight(),
+                    stableListPaddingBottom + insets.getSystemWindowInsetBottom());
+            return insets;
+        });
 
         customTab = new CustomTabActivityHelper();
         customTab.setConnectionCallback(customTabConnect);

--- a/designernews/src/main/res/values/styles.xml
+++ b/designernews/src/main/res/values/styles.xml
@@ -36,7 +36,7 @@
 
     <style name="Plaid.DesignerNews.Story">
         <item name="android:statusBarColor">@color/designer_news_variant</item>
-        <item name="android:navigationBarColor">@color/designer_news_super_dark</item>
+        <item name="android:navigationBarColor">@color/nav_bar</item>
         <item name="android:windowSharedElementEnterTransition">@transition/designer_news_story_shared_enter</item>
         <item name="android:windowSharedElementReturnTransition">@transition/designer_news_story_shared_return</item>
         <item name="android:windowEnterTransition">@transition/designer_news_story_enter</item>

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
@@ -24,11 +24,15 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.TypedValue
+import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.app.ShareCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import androidx.palette.graphics.Palette
 import com.bumptech.glide.load.DataSource
@@ -132,6 +136,17 @@ class ShotActivity : AppCompatActivity() {
                 shot.offset = -scrollY
             }
             back.setOnClickListener { setResultAndFinish() }
+        }
+
+        binding.draggableFrame.apply {
+            systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
+            setOnApplyWindowInsetsListener { _, insets ->
+                updateLayoutParams<MarginLayoutParams> { topMargin = insets.systemWindowInsetTop }
+                binding.bodyScroll.updatePadding(bottom = insets.systemWindowInsetBottom)
+                insets
+            }
         }
     }
 

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
@@ -137,17 +137,6 @@ class ShotActivity : AppCompatActivity() {
             }
             back.setOnClickListener { setResultAndFinish() }
         }
-
-        binding.draggableFrame.apply {
-            systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
-            setOnApplyWindowInsetsListener { _, insets ->
-                updateLayoutParams<MarginLayoutParams> { topMargin = insets.systemWindowInsetTop }
-                binding.bodyScroll.updatePadding(bottom = insets.systemWindowInsetBottom)
-                insets
-            }
-        }
     }
 
     override fun onResume() {

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
@@ -24,15 +24,11 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.util.TypedValue
-import android.view.View
-import android.view.ViewGroup.MarginLayoutParams
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.app.ShareCompat
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import androidx.palette.graphics.Palette
 import com.bumptech.glide.load.DataSource

--- a/dribbble/src/main/res/layout/activity_dribbble_shot.xml
+++ b/dribbble/src/main/res/layout/activity_dribbble_shot.xml
@@ -50,6 +50,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:transitionGroup="false"
+        app:layoutFullscreen="@{true}"
+        app:marginTopSystemWindowInsets="@{true}"
+        app:marginRightSystemWindowInsets="@{true}"
         app:dragDismissDistance="@dimen/drag_dismiss_distance"
         app:dragDismissScale="0.95"
         tools:context=".ui.shot.ShotActivity">
@@ -116,7 +119,8 @@
             android:clipToPadding="false"
             android:orientation="vertical"
             android:scrollbars="vertical"
-            android:scrollbarStyle="insideOverlay">
+            android:scrollbarStyle="insideOverlay"
+            app:paddingBottomSystemWindowInsets="@{true}">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"

--- a/dribbble/src/main/res/values/styles.xml
+++ b/dribbble/src/main/res/values/styles.xml
@@ -21,7 +21,6 @@
         <item name="android:colorPrimary">@color/dribbble</item>
         <item name="android:colorAccent">@color/dribbble</item>
         <item name="android:statusBarColor">@color/dribbble_super_dark</item>
-        <item name="android:navigationBarColor">@color/dribbble_super_dark</item>
         <item name="android:colorControlActivated">?android:colorAccent</item>
         <item name="android:windowAllowReturnTransitionOverlap">false</item>
     </style>

--- a/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
+++ b/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
@@ -33,6 +33,7 @@ import android.transition.TransitionSet
 import android.util.SparseArray
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.view.ViewStub
 import android.view.inputmethod.EditorInfo
 import android.widget.Button
@@ -45,6 +46,9 @@ import androidx.annotation.TransitionRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.set
 import androidx.core.text.toSpannable
+import androidx.core.view.marginBottom
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -104,6 +108,7 @@ class SearchActivity : AppCompatActivity() {
         setContentView(R.layout.activity_search)
         bindResources()
         setupSearchView()
+        setupInsets()
 
         Injector.inject(this)
 
@@ -197,6 +202,26 @@ class SearchActivity : AppCompatActivity() {
         resultsScrim = findViewById(R.id.results_scrim)
         resultsScrim.setOnClickListener { hideSaveConfirmation() }
         columns = resources.getInteger(io.plaidapp.core.R.integer.num_columns)
+    }
+
+    private fun setupInsets() {
+        container.apply {
+            systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
+            val stableFabMarginBottom = fab.marginBottom
+            setOnApplyWindowInsetsListener { _, insets ->
+                updatePadding(top = insets.systemWindowInsetTop)
+                results.updatePadding(bottom = insets.systemWindowInsetBottom)
+                fab.updateLayoutParams<MarginLayoutParams> {
+                    stableFabMarginBottom + insets.systemWindowInsetBottom
+                }
+                confirmSaveContainer.updateLayoutParams<MarginLayoutParams> {
+                    stableFabMarginBottom + insets.systemWindowInsetBottom
+                }
+                insets
+            }
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/search/src/main/res/values/styles.xml
+++ b/search/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
     <style name="Plaid.Translucent.Search">
         <item name="android:windowAnimationStyle">@style/SearchWindowAnimations</item>
         <item name="android:statusBarColor">@color/background_super_dark</item>
-        <item name="android:navigationBarColor">@color/background_super_dark</item>
+        <item name="android:navigationBarColor">@color/nav_bar</item>
         <item name="android:windowEnterTransition">@transition/search_enter</item>
         <item name="android:windowReturnTransition">@transition/search_return</item>
         <item name="android:windowSharedElementEnterTransition">@transition/search_shared_enter</item>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Update all screens to draw edge-to-edge.


## :bulb: Motivation and Context
This better supports gesture nav on Q+ devices, which may have minimal system UI.

Updated all screens to draw behind the navigation bar. Pre-Q we use a semi-transparent scrim to provide background protection for the nav buttons. On Q+ we set transparent nav bars (system will provide a scrim in 3-button nav mode).

Used @chrisbanes' [Data Binding adapters](https://medium.com/androiddevelopers/windowinsets-listeners-to-layouts-8f9ccc8fa4d1) to ease this on screens already using DB but used manual `WindowInsetListener`s on screens not yet using DB.

## :green_heart: How did you test it?
Manually.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
- Screens updating to Kotlin/Data Binding can be updated to use the Ext Funs or binding adapters.
- Update `DrawerLayout` to gesture friendly version when shippable artifact available.

## :camera_flash: Screenshots / GIFs
![Screenshot_1560348342](https://user-images.githubusercontent.com/352556/59359288-fe398680-8d25-11e9-8603-bc261a613ced.png)
![Screenshot_1560348350](https://user-images.githubusercontent.com/352556/59359289-fe398680-8d25-11e9-93b1-a62a11dd515c.png)
![Screenshot_1560348370](https://user-images.githubusercontent.com/352556/59359290-fe398680-8d25-11e9-8385-02226fcd7a8e.png)
![Screenshot_1560348372](https://user-images.githubusercontent.com/352556/59359291-fe398680-8d25-11e9-852a-4ee74f98d037.png)
![Screenshot_1560349265](https://user-images.githubusercontent.com/352556/59359292-fed21d00-8d25-11e9-898e-3abf077ae74f.png)
![Screenshot_1560349267](https://user-images.githubusercontent.com/352556/59359293-fed21d00-8d25-11e9-92c3-345a1c40d56a.png)
![Screenshot_1560349321](https://user-images.githubusercontent.com/352556/59359294-fed21d00-8d25-11e9-969f-4c0c54b803a5.png)
![Screenshot_1560349322](https://user-images.githubusercontent.com/352556/59359296-ff6ab380-8d25-11e9-8b8c-811c4b0f956a.png)

