### PR TITLE
Removes Retrofit coroutines adapter library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ buildscript { scriptHandler ->
             'mockito_kotlin'     : '2.0.0-RC3',
             'okhttp'             : '3.10.0',
             'retrofit'           : '2.6.0',
-            'retrofitCoroutines' : '0.9.2',
             'room'               : '2.1.0-alpha05',
             'supportLibrary'     : '28.0.0',
             'test_rules'         : '1.1.0-beta02',

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
@@ -17,7 +17,6 @@
 package io.plaidapp.core.dagger
 
 import com.google.gson.Gson
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Component
 import okhttp3.OkHttpClient
 import retrofit2.converter.gson.GsonConverterFactory
@@ -39,5 +38,4 @@ interface CoreComponent {
     fun provideOkHttpClient(): OkHttpClient
     fun provideGson(): Gson
     fun provideGsonConverterFactory(): GsonConverterFactory
-    fun provideCallAdapterFactory(): CoroutineCallAdapterFactory
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
@@ -17,7 +17,6 @@
 package io.plaidapp.core.dagger
 
 import com.google.gson.Gson
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.BuildConfig
@@ -45,9 +44,6 @@ class CoreDataModule {
                 HttpLoggingInterceptor.Level.NONE
             }
         }
-
-    @Provides
-    fun provideCallAdapterFactory(): CoroutineCallAdapterFactory = CoroutineCallAdapterFactory()
 
     @Provides
     @Singleton

--- a/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
@@ -16,7 +16,6 @@
 
 package io.plaidapp.core.dagger
 
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -60,29 +59,25 @@ class ProductHuntModule {
     fun provideProductHuntService(
         @ProductHuntApi okhttpClient: Lazy<OkHttpClient>,
         converterFactory: GsonConverterFactory,
-        deEnvelopingConverter: DeEnvelopingConverter,
-        callAdapterFactory: CoroutineCallAdapterFactory
+        deEnvelopingConverter: DeEnvelopingConverter
     ): ProductHuntService {
         return createRetrofit(
             okhttpClient,
             converterFactory,
-            deEnvelopingConverter,
-            callAdapterFactory
+            deEnvelopingConverter
         ).create(ProductHuntService::class.java)
     }
 
     private fun createRetrofit(
         okhttpClient: Lazy<OkHttpClient>,
         converterFactory: GsonConverterFactory,
-        deEnvelopingConverter: DeEnvelopingConverter,
-        callAdapterFactory: CoroutineCallAdapterFactory
+        deEnvelopingConverter: DeEnvelopingConverter
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(ProductHuntService.ENDPOINT)
             .callFactory { okhttpClient.get().newCall(it) }
             .addConverterFactory(deEnvelopingConverter)
             .addConverterFactory(converterFactory)
-            .addCallAdapterFactory(callAdapterFactory)
             .build()
     }
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -18,7 +18,6 @@ package io.plaidapp.core.dagger.designernews
 
 import android.content.SharedPreferences
 import com.google.gson.Gson
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -83,7 +82,6 @@ class DesignerNewsDataModule {
             .addConverterFactory(DeEnvelopingConverter(gson))
             .addConverterFactory(DesignerNewsSearchConverter.Factory())
             .addConverterFactory(GsonConverterFactory.create(gson))
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()
             .create(DesignerNewsService::class.java)
     }

--- a/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
@@ -16,7 +16,6 @@
 
 package io.plaidapp.core.dagger.dribbble
 
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -48,14 +47,12 @@ class DribbbleDataModule {
     @FeatureScope
     fun provideDribbbleSearchService(
         client: Lazy<OkHttpClient>,
-        converterFactory: DribbbleSearchConverter.Factory,
-        callAdapterFactory: CoroutineCallAdapterFactory
+        converterFactory: DribbbleSearchConverter.Factory
     ): DribbbleSearchService =
         Retrofit.Builder()
             .baseUrl(DribbbleSearchService.ENDPOINT)
             .callFactory { client.get().newCall(it) }
             .addConverterFactory(converterFactory)
-            .addCallAdapterFactory(callAdapterFactory)
             .build()
             .create(DribbbleSearchService::class.java)
 }

--- a/core_dependencies.gradle
+++ b/core_dependencies.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:${versions.retrofitCoroutines}"
     implementation "org.jsoup:jsoup:${versions.jsoup}"
     implementation "androidx.lifecycle:lifecycle-viewmodel:${versions.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}"

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -18,7 +18,6 @@ package io.plaidapp.designernews.dagger
 
 import android.content.Context
 import com.google.gson.Gson
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
@@ -48,7 +47,6 @@ class DataModule {
             .callFactory { client.get().newCall(it) }
             .addConverterFactory(DeEnvelopingConverter(gson))
             .addConverterFactory(GsonConverterFactory.create(gson))
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()
             .create(DesignerNewsService::class.java)
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
After https://github.com/android/plaid/pull/716, the Retrofit Coroutines Adapter is no longer needed.

## :green_heart: How did you test it?
Unit tests and running the app in the emulator

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing