### PR TITLE
Removed UI handling UpVotes for Stories and Comments

### DIFF
--- a/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryActivity.java
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryActivity.java
@@ -94,8 +94,6 @@ import static io.plaidapp.core.util.AnimUtils.getLinearOutSlowInInterpolator;
 
 public class StoryActivity extends AppCompatActivity {
 
-    private static final int RC_LOGIN_UPVOTE = 7;
-
     private View header;
     private RecyclerView commentsList;
     private LinearLayoutManager layoutManager;
@@ -110,7 +108,6 @@ public class StoryActivity extends AppCompatActivity {
     private PinnedOffsetView toolbarBackground;
     @Nullable
     private View background;
-    private TextView upvoteStory;
     private EditText enterComment;
     private ImageButton postComment;
     private int fabExpandDuration;
@@ -224,18 +221,6 @@ public class StoryActivity extends AppCompatActivity {
         fab.setAlpha(1f);
         fabExpand.setVisibility(View.INVISIBLE);
         draggableFrame.addListener(chromeFader);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        switch (requestCode) {
-            case RC_LOGIN_UPVOTE:
-                if (resultCode == RESULT_OK) {
-                    upvoteStory();
-                }
-                break;
-        }
     }
 
     @Override
@@ -461,9 +446,8 @@ public class StoryActivity extends AppCompatActivity {
             storyComment.setVisibility(View.GONE);
         }
 
-        upvoteStory = header.findViewById(R.id.story_vote_action);
-        storyUpvoted(story.getVoteCount());
-        upvoteStory.setOnClickListener(v -> upvoteStory());
+        TextView upvoteStory = header.findViewById(R.id.story_vote_action);
+        setVoteCountText(upvoteStory, story.getVoteCount());
 
         final TextView share = header.findViewById(R.id.story_share_action);
         share.setOnClickListener(v -> {
@@ -492,6 +476,12 @@ public class StoryActivity extends AppCompatActivity {
         } else {
             avatar.setVisibility(View.GONE);
         }
+    }
+
+    private void setVoteCountText(TextView upvoteStory, Integer voteCount) {
+        upvoteStory.setText(getResources().getQuantityString(
+                io.plaidapp.R.plurals.upvotes, voteCount,
+                NumberFormat.getInstance().format(voteCount)));
     }
 
     private CharSequence getStoryPosterTimeText(String userDisplayName, String userJob, Date createdAt) {
@@ -555,38 +545,6 @@ public class StoryActivity extends AppCompatActivity {
         enterComment.setEnabled(true);
         postComment.setEnabled(true);
         commentsAdapter.addComment(comment);
-    }
-
-    private void upvoteStory() {
-        if (loginRepository.isLoggedIn()) {
-            if (!upvoteStory.isActivated()) {
-                upvoteStory.setActivated(true);
-                viewModel.storyUpvoteRequested(story.getId(),
-                        it -> {
-                            if (it instanceof Result.Success) {
-                                storyUpvoted(story.getVoteCount() + 1);
-                            } else {
-                                Toast.makeText(this, "Unable to upvote story", Toast.LENGTH_LONG)
-                                        .show();
-                                upvoteStory.setActivated(false);
-                            }
-                            return Unit.INSTANCE;
-                        });
-
-            } else {
-                upvoteStory.setActivated(false);
-                // TODO delete upvote. Not available in v1 API.
-            }
-
-        } else {
-            needsLogin(upvoteStory, RC_LOGIN_UPVOTE);
-        }
-    }
-
-    private void storyUpvoted(int newUpvoteCount) {
-        upvoteStory.setText(getResources().getQuantityString(
-                io.plaidapp.R.plurals.upvotes, newUpvoteCount,
-                NumberFormat.getInstance().format(newUpvoteCount)));
     }
 
     private void needsLogin(View triggeringView, int requestCode) {
@@ -865,51 +823,10 @@ public class StoryActivity extends AppCompatActivity {
             });
         }
 
-        private void handleCommentVotesClick(CommentReplyViewHolder holder,
-                                             boolean isUserLoggedIn,
-                                             Comment comment) {
-            if (isUserLoggedIn) {
-                if (!holder.getCommentVotes().isActivated()) {
-                    viewModel.commentUpvoteRequested(story.getId(),
-                            result -> {
-                                if (result instanceof Result.Success) {
-                                    comment.setUpvoted(true);
-                                    // TODO fix this
-                                    // comment.vote_count++;
-                                    holder.getCommentVotes().setText(String.valueOf(comment.getUpvotesCount()));
-                                    holder.getCommentVotes().setActivated(true);
-                                } else {
-                                    Toast.makeText(StoryActivity.this, "Unable to upvote comment",
-                                            Toast.LENGTH_LONG)
-                                            .show();
-                                }
-                                return Unit.INSTANCE;
-                            });
-
-                } else {
-                    comment.setUpvoted(false);
-                    // TODO fix this
-//                    comment.setVoteCount(comment.getVoteCount() - 1);
-                    holder.getCommentVotes().setText(String.valueOf(comment.getUpvotesCount()));
-                    holder.getCommentVotes().setActivated(false);
-                    // TODO actually delete upvote - florina: why?
-                }
-            } else {
-                needsLogin(holder.getCommentVotes(), 0);
-            }
-            holder.getCommentReply().clearFocus();
-        }
-
-
         @NonNull
         private CommentReplyViewHolder createCommentReplyHolder(ViewGroup parent) {
             final CommentReplyViewHolder holder = new CommentReplyViewHolder(getLayoutInflater()
                     .inflate(R.layout.designer_news_comment_actions, parent, false));
-
-            holder.getCommentVotes().setOnClickListener(v -> {
-                Comment comment = getComment(holder.getAdapterPosition());
-                handleCommentVotesClick(holder, loginRepository.isLoggedIn(), comment);
-            });
 
             holder.getPostReply().setOnClickListener(v -> {
                 if (loginRepository.isLoggedIn()) {

--- a/designernews/src/main/res/layout/designer_news_story_description.xml
+++ b/designernews/src/main/res/layout/designer_news_story_description.xml
@@ -62,7 +62,8 @@
             android:layout_weight="2"
             android:drawableTop="@drawable/asl_upvote"
             tools:text="33 likes"
-            style="@style/Widget.Plaid.InlineActionButton" />
+            style="@style/Widget.Plaid.InlineActionButton"
+            android:background="@null" />
 
         <Space
             android:layout_width="0dp"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Removed UI action handling of Designer News Stories and Comments upvotes.

## :bulb: Motivation and Context
Designer News Server API have currently disabled upvotes of Stories and comments. This change avoid that an user tried to upvote something and fail.

## :green_heart: How did you test it?
No new features to test.

## :pencil: Checklist
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
Remove underlying functionality that handle upvotes.

## :camera_flash: Screenshots / GIFs

