### PR TITLE
Update build & target SDK to Q.

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
+++ b/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
@@ -19,10 +19,11 @@ package io.plaidapp.ui
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.Q
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 import androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode
-import androidx.core.os.BuildCompat
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.DaggerCoreComponent
 
@@ -33,7 +34,7 @@ class PlaidApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        val nightMode = if (BuildCompat.isAtLeastQ()) {
+        val nightMode = if (SDK_INT >= Q) {
             MODE_NIGHT_FOLLOW_SYSTEM
         } else {
             MODE_NIGHT_AUTO_BATTERY

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ buildscript { scriptHandler ->
     apply from: 'repositories.gradle',
             to: scriptHandler
     ext.versions = [
-            'compileSdk'         : 28,
+            'compileSdk'         : 29,
             'minSdk'             : 23,
-            'targetSdk'          : 28,
+            'targetSdk'          : 29,
             'appcompat'          : '1.1.0-alpha04',
             'androidx'           : '1.0.0',
             'androidxCollection' : '1.0.0',


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Update build & target sdk to 29, Android Q.


## :bulb: Motivation and Context
Now that [API 29 is final and apps built against it can be uploaded to Play](https://android-developers.googleblog.com/2019/06/android-q-beta-4-and-final-apis.html) we can update our sdk, enabling using new functionality (e.g. #671).

This change also replaces a usage of `BuildCompat` that is no longer valid out of the Q Betas.

## :green_heart: How did you test it?
Manually.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
Rebase and merge #671

## :camera_flash: Screenshots / GIFs
