### PR TITLE
Support screenshots resizing in the PR Template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -31,3 +31,4 @@
 
 ## :camera_flash: Screenshots / GIFs
 <!--- Mandatory for UI changes -->
+<img src="https://your_image_url" width="260">&emsp;<img src="https://your_image_url" width="260">


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Update `pull_request_template.md` to identify the UI changes easier in the section "**Screenshots / GIFs"**
 

## :bulb: Motivation and Context

When a screenshot is added looks biggest so it's complicated to review or understand the UI changes. (Here an example -> https://github.com/android/plaid/pull/721)


## :green_heart: How did you test it?
 manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
 The UI changes will be easy to identify

## :camera_flash: Screenshots / GIFs

 **Before**
![imagen](https://user-images.githubusercontent.com/5893477/59528532-2bac3e80-8ea4-11e9-9912-505fbc1b7d06.png)


**After**  
 <img src="https://user-images.githubusercontent.com/352556/59359288-fe398680-8d25-11e9-8603-bc261a613ced.png" width="260"> 
