### PR TITLE
Fix htmlUrl on Dribbble shots

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dribbble/data/search/DribbbleSearchConverter.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/search/DribbbleSearchConverter.kt
@@ -31,6 +31,8 @@ import java.util.Date
 import java.util.regex.Pattern
 
 private const val HOST = "https://dribbble.com"
+private const val SHOTS = "/shots/"
+
 private val PATTERN_PLAYER_ID = Pattern.compile("users/(\\d+?)/", Pattern.DOTALL)
 private val DATE_FORMAT = SimpleDateFormat("MMMM d, yyyy")
 
@@ -58,7 +60,7 @@ object DribbbleSearchConverter : Converter<ResponseBody, List<Shot>> {
 
     private fun parseShot(element: Element): Shot {
         val id = element.id().replace("screenshot-", "").toLong()
-        val htmlUrl = HOST + element.select("a.dribbble-link").first().attr("href")
+        val htmlUrl = HOST + SHOTS + id
         val descriptionBlock = element.select("a.dribbble-over").first()
         val title = descriptionBlock.select("strong").first().text()
         // API responses wrap description in a <p> tag. Do the same for consistent display.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Href was empty in "a.dribbble-link" so i set correct path of htmlUrl in parseShot function

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dribbble Shots link were not correct. Now on dribble pic click it navigate to correct URL.

## :green_heart: How did you test it?
Manually


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
![device-2019-06-17-173348](https://user-images.githubusercontent.com/25232443/59617261-4f7eb700-9126-11e9-84a9-ff612e936b24.png)
