### PR TITLE
#722 - remove SystemChromeFader from Dagger in Dribbble ShotActivity

### DIFF
--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -22,7 +22,6 @@ import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
-import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
 import io.plaidapp.core.util.FileAuthority
 import io.plaidapp.core.util.HtmlParser
 import io.plaidapp.dribbble.BuildConfig
@@ -44,15 +43,6 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     @Provides
     fun shotViewModel(factory: ShotViewModelFactory): ShotViewModel {
         return ViewModelProviders.of(activity, factory).get(ShotViewModel::class.java)
-    }
-
-    @Provides
-    fun chromeFader(): ElasticDragDismissFrameLayout.SystemChromeFader {
-        return object : ElasticDragDismissFrameLayout.SystemChromeFader(activity) {
-            override fun onDragDismissed() {
-                activity.setResultAndFinish()
-            }
-        }
     }
 
     @Provides

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotActivity.kt
@@ -57,7 +57,7 @@ class ShotActivity : AppCompatActivity() {
 
     @Inject
     internal lateinit var viewModel: ShotViewModel
-    @Inject
+
     internal lateinit var chromeFader: ElasticDragDismissFrameLayout.SystemChromeFader
 
     private val binding by contentView<ShotActivity, ActivityDribbbleShotBinding>(
@@ -132,6 +132,12 @@ class ShotActivity : AppCompatActivity() {
                 shot.offset = -scrollY
             }
             back.setOnClickListener { setResultAndFinish() }
+        }
+
+        chromeFader = object : ElasticDragDismissFrameLayout.SystemChromeFader(this) {
+            override fun onDragDismissed() {
+                setResultAndFinish()
+            }
         }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Removed the `ChromeFader` from Dagger injection for Dribbble's `ShotActivity`

## :bulb: Motivation and Context
Fixes #722 - happened because the injection of `ChromeFader` happening before the activity setContentView (because of the lazy delegate). The `ChromeFader` sees that the activity has no content view yet and sets status bar alpha to 0.  I think the cleanest solution is to just remove the `ChromeFader` from the injection, so we get to keep the lazy delegate (yay Kotlin)

## :green_heart: How did you test it?
Just visually inspected it on my device (Xiaomi Mi A1, API 28).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing

## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs


![plaid](https://user-images.githubusercontent.com/7274014/60041380-94928280-96fe-11e9-9c74-3cd9e6f132dd.gif)
