### PR TITLE
Update CircleCI image to use Android API 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   plaid-android-executor:
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-29
     working_directory: ~/plaid
     environment:
       JAVA_TOOL_OPTIONS: "-Xmx1536m"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description
Update the Circle CI config file to run the build and tests on an image with Android API level 29.

## :bulb: Motivation and Context
Updating the CI files allows us to test API 29 features in CI.

## :green_heart: How did you test it?
Circle CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing

## :crystal_ball: Next steps
Update build.gradle with API 29 changes.

## :camera_flash: Screenshots / GIFs
N/A
