### PR TITLE
Align creation of ViewModels

### DIFF
--- a/about/src/main/java/io/plaidapp/about/ui/model/AboutViewModel.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/model/AboutViewModel.kt
@@ -32,13 +32,12 @@ import io.plaidapp.about.R
 import io.plaidapp.about.domain.model.Library
 import io.plaidapp.about.ui.AboutStyler
 import io.plaidapp.core.util.event.Event
-import javax.inject.Inject
 import kotlin.LazyThreadSafetyMode.NONE
 
 /**
  * [ViewModel] for the [io.plaidapp.about.ui.AboutActivity].
  */
-internal class AboutViewModel @Inject constructor(
+internal class AboutViewModel(
     private val aboutStyler: AboutStyler,
     private val resources: Resources,
     private val markdown: Markdown

--- a/about/src/main/java/io/plaidapp/about/ui/model/AboutViewModelFactory.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/model/AboutViewModelFactory.kt
@@ -16,26 +16,31 @@
 
 package io.plaidapp.about.ui.model
 
+import `in`.uncod.android.bypass.Markdown
+import android.content.res.Resources
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import io.plaidapp.about.ui.AboutStyler
 import javax.inject.Inject
 
 /**
  * Factory to create [AboutViewModel]
  */
-
-internal class AboutViewModelFactory @Inject constructor() : ViewModelProvider.Factory {
-
-    @Inject lateinit var aboutViewModel: AboutViewModel
+class AboutViewModelFactory @Inject constructor(
+    private val aboutStyler: AboutStyler,
+    private val resources: Resources,
+    private val markdown: Markdown
+) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return if (modelClass.isAssignableFrom(AboutViewModel::class.java)) {
-            aboutViewModel as T
-        } else {
-            throw IllegalArgumentException(
-                "Class ${modelClass.name} is not supported in this factory."
-            )
+        if (modelClass != AboutViewModel::class) {
+            throw IllegalArgumentException("Unknown ViewModel class")
         }
+        return AboutViewModel(
+            aboutStyler,
+            resources,
+            markdown
+        ) as T
     }
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/DesignerNewsViewModelFactory.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/DesignerNewsViewModelFactory.kt
@@ -33,9 +33,12 @@ class DesignerNewsViewModelFactory @Inject constructor(
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
-            return LoginViewModel(loginRepository, dispatcherProvider) as T
+        if (modelClass != LoginViewModel::class.java) {
+            throw IllegalArgumentException("Unknown ViewModel class")
         }
-        throw IllegalArgumentException("Unknown ViewModel class")
+        return LoginViewModel(
+            loginRepository,
+            dispatcherProvider
+        ) as T
     }
 }

--- a/search/src/main/java/io/plaidapp/search/ui/SearchViewModelFactory.kt
+++ b/search/src/main/java/io/plaidapp/search/ui/SearchViewModelFactory.kt
@@ -35,6 +35,9 @@ class SearchViewModelFactory @Inject constructor(
         if (modelClass != SearchViewModel::class.java) {
             throw IllegalArgumentException("Unknown ViewModel class")
         }
-        return SearchViewModel(registry, dispatcherProvider) as T
+        return SearchViewModel(
+            registry,
+            dispatcherProvider
+        ) as T
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description
`AboutViewModelFactory` injects an instance of `AboutViewModel` into itself which is in turn injected into `AboutActivity` every time the activity is created or recreated, causing an unused instance to be generated even when a reused instance is provided by `viewModels { … }`.

## :bulb: Motivation and Context
I was going through various `ViewModelProvider.Factory` implementations and I stumbled across this inconsistency which had been bugging me 😂 

## :green_heart: How did you test it?
Manually ran tests and built locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing

## :crystal_ball: Next steps
Other instances of `ViewModelProvider.Factory` are not internal, I would rather keep them all internal but I opted for consistency, though I can update the others to be internal if requested.

I've been using a mechanism for generating `ViewModel` providers in our project which uses a similar style to what is done here, however instead of providing each of the dependencies you provide a `Provider<T>` to an abstract `Factory` which can be injected, slightly reducing boilerplate.

Some feedback on whether it might be appropriate for Plaid 👍 
https://gist.github.com/ashdavies/5570d610a7e6ea5a4c8898f16d38bc3a

## :camera_flash: Screenshots / GIFs
No visual changes
