### PR TITLE
Fix incorrectly checking of AboutViewModelFactory

### DIFF
--- a/about/src/main/java/io/plaidapp/about/ui/model/AboutViewModelFactory.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/model/AboutViewModelFactory.kt
@@ -34,7 +34,7 @@ class AboutViewModelFactory @Inject constructor(
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        if (modelClass != AboutViewModel::class) {
+        if (modelClass != AboutViewModel::class.java) {
             throw IllegalArgumentException("Unknown ViewModel class")
         }
         return AboutViewModel(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The app crash when you tap on "About". Turns out it check `KClass` instead of `Class`, and the verification in `AboutViewModelFactory` throws `IllegalArgumentException`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix "click About and immediately crash"

## :green_heart: How did you test it?
I click "About" again and see if it crash

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps

Should I add a test here? I checked other `XXXViewModelFactory`, and it doesn't seem like any of them have test either 🤷‍♀ 

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->

### Before
<img width="769" alt="before" src="https://user-images.githubusercontent.com/3873011/61995168-e3786280-b084-11e9-8500-77e9ffb87390.png">

### After

No crash 😁 