### PR TITLE
Move secrets to from gradle.properties to local.properties  avoiding …

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -32,12 +32,13 @@ android {
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
-        buildConfigField 'String', 'DESIGNER_NEWS_CLIENT_ID', "\"${designer_news_client_id}\""
         buildConfigField 'String',
-                'DESIGNER_NEWS_CLIENT_SECRET', "\"${designer_news_client_secret}\""
+                'DESIGNER_NEWS_CLIENT_ID', "\"${getLocalProperty('designer.news.client.id')}\""
+        buildConfigField 'String',
+                'DESIGNER_NEWS_CLIENT_SECRET', "\"${getLocalProperty('designer.news.client.secret')}\""
 
         buildConfigField 'String',
-                'PRODUCT_HUNT_DEVELOPER_TOKEN', "\"${product_hunt_developer_token}\""
+                'PRODUCT_HUNT_DEVELOPER_TOKEN', "\"${getLocalProperty('product.hunt.developer.token')}\""
 
         javaCompileOptions {
             annotationProcessorOptions {
@@ -90,4 +91,10 @@ kapt {
 
 androidExtensions {
     experimental = true
+}
+
+def getLocalProperty(String propertyName) {
+    Properties properties = new Properties()
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    return properties.getProperty(propertyName)
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -94,7 +94,11 @@ androidExtensions {
 }
 
 def getLocalProperty(String propertyName) {
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    return properties.getProperty(propertyName)
+    try {
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        return properties.getProperty(propertyName)
+    } catch(ignored) {
+        return "Missing property"
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,11 +19,6 @@ kapt.incremental.apt=true
 # Use kapt in parallel
 kapt.use.worker.api=true
 
-# Design News API
-designer_news_client_id = <your designer news client id>
-designer_news_client_secret = <your designer news client secret>
-
-# Product Hunt API
-product_hunt_developer_token = <your product hunt developer token>
+# AndroidX package structure
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Manage secrets is always a challenge in android, due this, store them in `gradle.properties` is the solution that is applied in this open-source project, but that create an inconvenience about git changes when modify that file with correctly secrets value, and is easy to push it accidentally. To improve this I move that secrets to file: `local.properties`

## :bulb: Motivation and Context
Recently I did the same implementation in a personal open-source project, and I decide to submit these changes there.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing

## :crystal_ball: Next steps
It's interesting to add in the future a exception message on build project like the following example giving detail information about how to set-up it: 

```
try {
      it.buildConfigField "String", "MARVEL_BASE_URL", "\"http://gateway.marvel.com\""
      it.buildConfigField "String", "MARVEL_PUBLIC_KEY", "\"${getLocalProperty("marvel.key.public")}\""
      it.buildConfigField "String", "MARVEL_PRIVATE_KEY", "\"${getLocalProperty("marvel.key.private")}\""
    } catch (ignored) {
      throw new InvalidUserDataException("You should define 'marvel_public_key' and 'marvel_private_key' in local.properties. Visit 'https://developer.marvel.com' to obtain them.")
    }
```


## :camera_flash: Screenshots / GIFs
![Screenshot 2019-08-16 at 18 15 15](https://user-images.githubusercontent.com/18151158/63185373-24e3a880-c05a-11e9-82fe-fb780aa5e3b4.png)
