### PR TITLE
Uses new method getOrAwaitValue to test LiveData emissions

### DIFF
--- a/about/src/test/java/io/plaidapp/about/ui/model/AboutViewModelTest.kt
+++ b/about/src/test/java/io/plaidapp/about/ui/model/AboutViewModelTest.kt
@@ -25,7 +25,7 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.plaidapp.about.ui.AboutStyler
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -73,8 +73,8 @@ class AboutViewModelTest {
         // Click on all the libraries
         aboutViewModel.libraries.forEach {
             aboutViewModel.onLibraryClick(it)
-            val event = LiveDataTestUtil.getValue(aboutViewModel.navigationTarget)
-            assertThat(event?.peek(), `is`(equalTo(it.link)))
+            val event = aboutViewModel.navigationTarget.getOrAwaitValue()
+            assertThat(event.peek(), `is`(equalTo(it.link)))
         }
     }
 }

--- a/app/src/test/java/io/plaidapp/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/io/plaidapp/ui/HomeViewModelTest.kt
@@ -43,7 +43,7 @@ import io.plaidapp.post
 import io.plaidapp.shot
 import io.plaidapp.story
 import io.plaidapp.test.shared.MainCoroutineRule
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import io.plaidapp.test.shared.runBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -185,13 +185,13 @@ class HomeViewModelTest {
         filtersChangedCallback.value.onFiltersUpdated(listOf(designerNewsSource, dribbbleSource))
 
         // Then ui model sources are emitted
-        val sources = LiveDataTestUtil.getValue(homeViewModel.sources)
+        val sources = homeViewModel.sources.getOrAwaitValue()
         // Then all sources are highlighted
         val sourcesHighlightUiModel = SourcesHighlightUiModel(
             highlightPositions = listOf(0, 1),
             scrollToPosition = 1
         )
-        assertEquals(sourcesHighlightUiModel, sources?.highlightSources!!.peek())
+        assertEquals(sourcesHighlightUiModel, sources.highlightSources!!.peek())
         // The expected sources are retrieved
         assertEquals(2, sources.sourceUiModels.size)
     }
@@ -210,13 +210,13 @@ class HomeViewModelTest {
         filtersChangedCallback.value.onFiltersUpdated(sources)
 
         // Then ui model sources are emitted
-        val sourcesUiModel = LiveDataTestUtil.getValue(homeViewModel.sources)
+        val sourcesUiModel = homeViewModel.sources.getOrAwaitValue()
         // Then all sources are highlighted
         val sourcesHighlightUiModel = SourcesHighlightUiModel(
             highlightPositions = listOf(1),
             scrollToPosition = 1
         )
-        assertEquals(sourcesHighlightUiModel, sourcesUiModel?.highlightSources!!.peek())
+        assertEquals(sourcesHighlightUiModel, sourcesUiModel.highlightSources!!.peek())
         // The expected sources are retrieved
         assertEquals(2, sourcesUiModel.sourceUiModels.size)
     }
@@ -231,7 +231,7 @@ class HomeViewModelTest {
         // Given that filters were updated
         filtersChangedCallback.value.onFiltersUpdated(listOf(designerNewsSource))
         // Given that ui model sources are emitted
-        val sources = LiveDataTestUtil.getValue(homeViewModel.sources)!!
+        val sources = homeViewModel.sources.getOrAwaitValue()
         val uiSource = sources.sourceUiModels[0]
 
         // When calling sourceClicked
@@ -251,8 +251,8 @@ class HomeViewModelTest {
         // Given that filters were updated
         filtersChangedCallback.value.onFiltersUpdated(listOf(designerNewsSource))
         // Given that ui model sources are emitted
-        val sources = LiveDataTestUtil.getValue(homeViewModel.sources)
-        val uiSource = sources!!.sourceUiModels[0]
+        val sources = homeViewModel.sources.getOrAwaitValue()
+        val uiSource = sources.sourceUiModels[0]
 
         // When calling onSourceDismissed
         uiSource.onSourceDismissed(designerNewsSourceUiModel.copy(isSwipeDismissable = true))
@@ -271,8 +271,8 @@ class HomeViewModelTest {
         // Given that filters were updated
         filtersChangedCallback.value.onFiltersUpdated(listOf(designerNewsSource))
         // Given that ui model sources are emitted
-        val sources = LiveDataTestUtil.getValue(homeViewModel.sources)
-        val uiSource = sources!!.sourceUiModels[0]
+        val sources = homeViewModel.sources.getOrAwaitValue()
+        val uiSource = sources.sourceUiModels[0]
 
         // When calling onSourceDismissed
         uiSource.onSourceDismissed(designerNewsSourceUiModel.copy(isSwipeDismissable = false))
@@ -293,8 +293,8 @@ class HomeViewModelTest {
         filtersChangedCallback.value.onFilterRemoved(dribbbleSource.key)
 
         // Then feed emits a new list, without the removed filter
-        val feed = LiveDataTestUtil.getValue(homeViewModel.getFeed(columns))
-        assertEquals(listOf(post, story), feed!!.items)
+        val feed = homeViewModel.getFeed(columns).getOrAwaitValue()
+        assertEquals(listOf(post, story), feed.items)
     }
 
     @Test
@@ -304,14 +304,14 @@ class HomeViewModelTest {
         verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
-        val initialFeed = LiveDataTestUtil.getValue(homeViewModel.getFeed(columns))
+        val initialFeed = homeViewModel.getFeed(columns).getOrAwaitValue()
 
         // When an active source was changed
         val activeSource = DribbbleSourceItem("dribbble", true)
         filtersChangedCallback.value.onFiltersChanged(activeSource)
 
         // Then feed didn't emit a new value
-        val feed = LiveDataTestUtil.getValue(homeViewModel.getFeed(columns))
+        val feed = homeViewModel.getFeed(columns).getOrAwaitValue()
         assertEquals(initialFeed, feed)
     }
 
@@ -328,8 +328,8 @@ class HomeViewModelTest {
         filtersChangedCallback.value.onFiltersChanged(inactiveSource)
 
         // Then feed emits a new list, without the removed filter
-        val feed = LiveDataTestUtil.getValue(homeViewModel.getFeed(columns))
-        assertEquals(listOf(post, story), feed!!.items)
+        val feed = homeViewModel.getFeed(columns).getOrAwaitValue()
+        assertEquals(listOf(post, story), feed.items)
     }
 
     @Test
@@ -342,7 +342,7 @@ class HomeViewModelTest {
         dataLoadingCallback.value.dataStartedLoading()
 
         // Then the feedProgress emits true
-        val progress = LiveDataTestUtil.getValue(homeViewModel.feedProgress)
+        val progress = homeViewModel.feedProgress.getOrAwaitValue()
         assertEquals(FeedProgressUiModel(true), progress)
     }
 
@@ -356,7 +356,7 @@ class HomeViewModelTest {
         dataLoadingCallback.value.dataFinishedLoading()
 
         // Then the feedProgress emits false
-        val progress = LiveDataTestUtil.getValue(homeViewModel.feedProgress)
+        val progress = homeViewModel.feedProgress.getOrAwaitValue()
         assertEquals(FeedProgressUiModel(false), progress)
     }
 
@@ -379,8 +379,8 @@ class HomeViewModelTest {
         dataLoadedCallback.value.onDataLoaded(listOf(post, shot, story))
 
         // Then feed emits a new list
-        val feed = LiveDataTestUtil.getValue(homeViewModel.getFeed(2))
-        assertEquals(listOf(post, story, shot), feed!!.items)
+        val feed = homeViewModel.getFeed(2).getOrAwaitValue()
+        assertEquals(listOf(post, story, shot), feed.items)
     }
 
     private fun createViewModelWithFeedData(feedData: List<PlaidItem>): HomeViewModel {

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-alpha07'
+        classpath 'com.android.tools.build:gradle:3.6.0-alpha12'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/designernews/src/androidTest/java/io/plaidapp/designernews/data/database/LoggedInUserDaoTest.kt
+++ b/designernews/src/androidTest/java/io/plaidapp/designernews/data/database/LoggedInUserDaoTest.kt
@@ -21,7 +21,7 @@ import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -66,7 +66,7 @@ class LoggedInUserDaoTest {
         loggedInUserDao.setLoggedInUser(loggedInUser)
 
         // When getting the LoggedInUser via the DAO
-        val userFromDb = LiveDataTestUtil.getValue(loggedInUserDao.getLoggedInUser())
+        val userFromDb = loggedInUserDao.getLoggedInUser().getOrAwaitValue()
 
         // Then the retrieved LoggedInUser matches the original LoggedInUser object
         assertEquals(loggedInUser, userFromDb)
@@ -88,7 +88,7 @@ class LoggedInUserDaoTest {
         loggedInUserDao.setLoggedInUser(updatedUser)
 
         // Then a subsequent query for the LoggedInUser should show the updated information
-        val userFromDb = LiveDataTestUtil.getValue(loggedInUserDao.getLoggedInUser())
+        val userFromDb = loggedInUserDao.getLoggedInUser().getOrAwaitValue()
         assertEquals(updatedUser, userFromDb)
     }
 
@@ -108,7 +108,7 @@ class LoggedInUserDaoTest {
         loggedInUserDao.setLoggedInUser(newUser)
 
         // Then a query for LoggedInUser should return the new user
-        val userFromDb = LiveDataTestUtil.getValue(loggedInUserDao.getLoggedInUser())
+        val userFromDb = loggedInUserDao.getLoggedInUser().getOrAwaitValue()
         assertEquals(newUser, userFromDb)
     }
 
@@ -120,7 +120,7 @@ class LoggedInUserDaoTest {
         loggedInUserDao.deleteLoggedInUser()
 
         // Then a query for the LoggedInUser should be null
-        val userFromDb = LiveDataTestUtil.getValue(loggedInUserDao.getLoggedInUser())
+        val userFromDb = loggedInUserDao.getLoggedInUser().getOrAwaitValue()
         assertNull(userFromDb)
     }
 }

--- a/designernews/src/test/java/io/plaidapp/designernews/ui/login/LoginViewModelTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/ui/login/LoginViewModelTest.kt
@@ -26,7 +26,7 @@ import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
 import io.plaidapp.core.util.event.Event
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -81,7 +81,7 @@ class LoginViewModelTest {
             showSuccess = Event(LoginResultUiModel("plaida plaidich", "www")),
             enableLoginButton = false
         )
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(expected, uiState)
     }
 
@@ -103,7 +103,7 @@ class LoginViewModelTest {
             showSuccess = null,
             enableLoginButton = true
         )
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(expectedUiModel, uiState)
     }
 
@@ -113,7 +113,7 @@ class LoginViewModelTest {
         val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // Then the login is disabled
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(initialUiModel, uiState)
     }
 
@@ -133,8 +133,8 @@ class LoginViewModelTest {
             enableLoginButton = true
         )
         // TODO leave only the last assert
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
-        assertEquals(expectedUiModel.showProgress, uiState!!.showProgress)
+        val uiState = viewModel.uiState.getOrAwaitValue()
+        assertEquals(expectedUiModel.showProgress, uiState.showProgress)
         assertEquals(expectedUiModel.showError, uiState.showError)
         assertEquals(expectedUiModel.showSuccess, uiState.showSuccess)
         assertEquals(expectedUiModel.enableLoginButton, uiState.enableLoginButton)
@@ -156,7 +156,7 @@ class LoginViewModelTest {
             showSuccess = null,
             enableLoginButton = false
         )
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(expectedUiModel, uiState)
     }
 
@@ -175,7 +175,7 @@ class LoginViewModelTest {
             showSuccess = null,
             enableLoginButton = false
         )
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(expectedUiModel, uiState)
     }
 
@@ -190,7 +190,7 @@ class LoginViewModelTest {
         // Then login is not triggered
         verify(loginRepo, never()).login(username, "")
         // Then the UI state is the initial state
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(initialUiModel, uiState)
     }
 
@@ -205,7 +205,7 @@ class LoginViewModelTest {
         // Then login is not triggered
         verify(loginRepo, never()).login(username, "")
         // Then the UI state is the initial state
-        val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
+        val uiState = viewModel.uiState.getOrAwaitValue()
         assertEquals(initialUiModel, uiState)
     }
 
@@ -218,7 +218,7 @@ class LoginViewModelTest {
         viewModel.signup()
 
         // Then an open url event is emitted
-        val url = LiveDataTestUtil.getValue(viewModel.openUrl)
+        val url = viewModel.openUrl.getOrAwaitValue()
         assertNotNull(url)
     }
 }

--- a/designernews/src/test/java/io/plaidapp/designernews/ui/story/StoryViewModelTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/ui/story/StoryViewModelTest.kt
@@ -29,7 +29,7 @@ import io.plaidapp.designernews.domain.PostReplyUseCase
 import io.plaidapp.designernews.domain.PostStoryCommentUseCase
 import io.plaidapp.designernews.flattendCommentsWithReplies
 import io.plaidapp.designernews.reply1
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -107,8 +107,8 @@ class StoryViewModelTest {
         val viewModel = withViewModel()
 
         // Then the correct UI model is created
-        val event = LiveDataTestUtil.getValue(viewModel.uiModel)
-        assertEquals(event!!.comments, flattendCommentsWithReplies)
+        val event = viewModel.uiModel.getOrAwaitValue()
+        assertEquals(event.comments, flattendCommentsWithReplies)
     }
 
     @Test

--- a/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
@@ -24,13 +24,12 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.api.model.Shot
-import io.plaidapp.core.util.event.Event
 import io.plaidapp.dribbble.domain.CreateShotUiModelUseCase
 import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
 import io.plaidapp.dribbble.domain.ShareShotInfo
 import io.plaidapp.dribbble.testShot
 import io.plaidapp.dribbble.testShotUiModel
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -73,7 +72,7 @@ class ShotViewModelTest {
         val viewModel = withViewModel()
 
         // Then a shotUiModel is present
-        val result: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
+        val result = viewModel.shotUiModel.getOrAwaitValue()
         assertNotNull(result)
     }
 
@@ -105,9 +104,8 @@ class ShotViewModelTest {
         viewModel.viewShotRequested()
 
         // Then an event is emitted to open the given url
-        val openLinkEvent: Event<String>? = LiveDataTestUtil.getValue(viewModel.openLink)
-        assertNotNull(openLinkEvent)
-        assertEquals(url, openLinkEvent!!.peek())
+        val openLinkEvent = viewModel.openLink.getOrAwaitValue()
+        assertEquals(url, openLinkEvent.peek())
     }
 
     @Test
@@ -120,9 +118,8 @@ class ShotViewModelTest {
         viewModel.shareShotRequested()
 
         // Then an event is raised with the expected info
-        val shareInfoEvent: Event<ShareShotInfo>? = LiveDataTestUtil.getValue(viewModel.shareShot)
-        assertNotNull(shareInfoEvent)
-        assertEquals(expected, shareInfoEvent!!.peek())
+        val shareInfoEvent = viewModel.shareShot.getOrAwaitValue()
+        assertEquals(expected, shareInfoEvent.peek())
     }
 
     @Test
@@ -162,17 +159,15 @@ class ShotViewModelTest {
         val viewModel = withViewModel()
 
         // Then the fast result has been emitted
-        val fastResult: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
-        assertNotNull(fastResult)
-        assertTrue(fastResult!!.formattedDescription.isEmpty())
+        val fastResult = viewModel.shotUiModel.getOrAwaitValue()
+        assertTrue(fastResult.formattedDescription.isEmpty())
 
         // When the coroutine starts
         testCoroutineDispatcher.resumeDispatcher()
 
         // Then the slow result has been emitted
-        val slowResult: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
-        assertNotNull(slowResult)
-        assertTrue(slowResult!!.formattedDescription.isNotEmpty())
+        val slowResult = viewModel.shotUiModel.getOrAwaitValue()
+        assertTrue(slowResult.formattedDescription.isNotEmpty())
     }
 
     private fun withViewModel(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/search/src/test/java/io/plaidapp/search/ui/SearchViewModelTest.kt
+++ b/search/src/test/java/io/plaidapp/search/ui/SearchViewModelTest.kt
@@ -28,7 +28,7 @@ import io.plaidapp.search.domain.SearchDataSourceFactoriesRegistry
 import io.plaidapp.search.shots
 import io.plaidapp.search.testShot1
 import io.plaidapp.test.shared.MainCoroutineRule
-import io.plaidapp.test.shared.LiveDataTestUtil
+import io.plaidapp.test.shared.getOrAwaitValue
 import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import io.plaidapp.test.shared.runBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -75,8 +75,8 @@ class SearchViewModelTest {
         viewModel.searchFor(query)
 
         // Then search results emits with the data that was passed initially
-        val results = LiveDataTestUtil.getValue(viewModel.searchResults)
-        assertEquals(results!!.items, result.data)
+        val results = viewModel.searchResults.getOrAwaitValue()
+        assertEquals(results.items, result.data)
     }
 
     @Test
@@ -95,8 +95,8 @@ class SearchViewModelTest {
         viewModel.loadMore()
 
         // Then search results emits with the data that was passed
-        val results = LiveDataTestUtil.getValue(viewModel.searchResults)
-        assertEquals(results!!.items, moreResult.data)
+        val results = viewModel.searchResults.getOrAwaitValue()
+        assertEquals(results.items, moreResult.data)
     }
 }
 

--- a/test_shared/src/main/java/io/plaidapp/test/shared/LiveDataTestUtil.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/LiveDataTestUtil.kt
@@ -21,29 +21,38 @@ import androidx.lifecycle.Observer
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 /**
- * Safely handles observables from LiveData for testing.
+ * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
+ *
+ * Use this extension from host-side (JVM) tests. It's recommended to use it alongside
+ * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
  */
-object LiveDataTestUtil {
-
-    /**
-     * Gets the value of a LiveData safely.
-     */
-    @Throws(InterruptedException::class)
-    fun <T> getValue(liveData: LiveData<T>): T? {
-        var data: T? = null
-        val latch = CountDownLatch(1)
-        val observer = object : Observer<T> {
-            override fun onChanged(o: T?) {
-                data = o
-                latch.countDown()
-                liveData.removeObserver(this)
-            }
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
         }
-        liveData.observeForever(observer)
-        latch.await(2, TimeUnit.SECONDS)
-
-        return data
     }
+    this.observeForever(observer)
+
+    afterObserve.invoke()
+
+    // Don't wait indefinitely if the LiveData is not set.
+    if (!latch.await(time, timeUnit)) {
+        this.removeObserver(observer)
+        throw TimeoutException("LiveData value was never set.")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Changes usages of LiveDataTestUtil for getValue for getOrAwaitValue LiveData extension function

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The recommended way to test LiveData emissions is with the getOrAwaitValue function.

https://medium.com/androiddevelopers/unit-testing-livedata-and-other-common-observability-problems-bb477262eb04

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
