### PR TITLE
Add memory setting for unit tests in Gradle files

### DIFF
--- a/about/build.gradle
+++ b/about/build.gradle
@@ -43,6 +43,12 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
+
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,12 @@ android {
     }
 
     dynamicFeatures = [':about', ':designernews', ':dribbble', ':search']
+
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ buildscript { scriptHandler ->
     ext.names = [
             'applicationId': 'io.plaidapp'
     ]
+    ext.settings = [
+            'maxHeapSize': '1024m'
+    ]
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.0-beta05'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,6 +62,12 @@ android {
         exclude 'META-INF/core_debug.kotlin_module'
     }
 
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
+
 }
 
 dependencies {

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -45,6 +45,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
 }
 
 dependencies {

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -43,6 +43,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
 }
 
 dependencies {

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -36,6 +36,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
 }
 
 dependencies {

--- a/test_shared/build.gradle
+++ b/test_shared/build.gradle
@@ -37,6 +37,12 @@ android {
     packagingOptions {
         exclude 'META-INF/test_shared_debug.kotlin_module'
     }
+
+    testOptions {
+        unitTests.all {
+            maxHeapSize = settings.maxHeapSize
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This is to try and fix the OOM issues on CircleCI.  This changed is based on recommendations from CircleCI articles:

- https://circleci.com/blog/how-to-handle-java-oom-errors/
- https://circleci.com/docs/2.0/language-android/#handling-out-of-memory-errors

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
android / platform / external / libjpeg-turbo / d3db2a2634c422286f75c4b38af98837f3d2f0ff / . / Android.bp

blob: e3454fdbe8d9662940747c92e9703c0b39cb1d4b [ archivo ] [ log ] [ culpa ]

// Configure variables comunes para su uso en los módulos libjpeg-turbocc_defaults { nombre : "libjpeg-defaults" , banderas : [ "-O3" , "-fstrict-aliasing" , "-Werror" , "-No firmar-comparar" , "-Sin parámetro no utilizado" , ], srcs : [ "jaricom.c" , "jcapimin.c" , "jcapistd.c" , "jcarith.c" , "jccoefct.c" , "jccolor.c" , "jcdctmgr.c" , "jchuff.c" , "jcinit.c" , "jcmainct.c" , "jcmarker.c" , "jcmaster.c" , "jcomapi.c" , "jcparam.c" , "jcphuff.c" , "jcprepct.c" , "jcsample.c" , "jctrans.c" , "jdapimin.c" , "jdapistd.c" , "jdarith.c" , "jdatadst.c" , "jdatasrc.c" , "jdcoefct.c" , "jdcolor.c" , "jddctmgr.c" , "jdhuff.c" , "jdinput.c" , "jdmainct.c" , "jdmarker.c" , "jdmaster.c" , "jdmerge.c" , "jdphuff.c" , "jdpostct.c" , "jdsample.c" , "jdtrans.c" , "jerror.c" , "jfdctflt.c" , "jfdctfst.c" , "jfdctint.c" , "jidctflt.c" , "jidctfst.c" , "jidctint.c" , "jidctred.c" , "jmemmgr.c" , "jmemnobs.c" , "jquant1.c" , "jquant2.c" , "jutils.c" , ], arco : { brazo : { // Por defecto, el sistema de compilación genera binarios de destino ARM en // modo pulgar, donde cada instrucción tiene 16 bits de ancho. Definir // esta variable como brazo fuerza al sistema de construcción a generar objetos // archivos en modo de armado de 32 bits. Esta es la misma configuración anteriormente // utilizado por libjpeg y proporciona un pequeño beneficio de rendimiento. conjunto_instrucciones : "brazo" , // BRAZO v7 NEON srcs : [ "simd / arm / jsimd.c" , "simd / arm / jsimd_neon.S" , ], }, arm64 : { // ARM v8 64-bit NEON srcs : [ "simd / arm64 / jsimd.c" , "simd / arm64 / jsimd_neon.S" , ], }, x86 : { // x86 MMX y SSE2 srcs : [ "simd / i386 / jccolor-avx2.asm" , "simd / i386 / jccolor-mmx.asm" , "simd / i386 / jccolor-sse2.asm" , "simd / i386 / jcgray-avx2.asm" , "simd / i386 / jcgray-mmx.asm" , "simd / i386 / jcgray-sse2.asm" , "simd / i386 / jchuff-sse2.asm" , "simd / i386 / jcphuff-sse2.asm" , "simd / i386 / jcsample-avx2.asm" , "simd / i386 / jcsample-mmx.asm" , "simd / i386 / jcsample-sse2.asm" , "simd / i386 / jdcolor-avx2.asm" , "simd / i386 / jdcolor-mmx.asm" , "simd / i386 / jdcolor-sse2.asm" , "simd / i386 / jdmerge-avx2.asm" , "simd / i386 / jdmerge-mmx.asm" , "simd / i386 / jdmerge-sse2.asm" , "simd / i386 / jdsample-avx2.asm" , "simd / i386 / jdsample-mmx.asm" , "simd / i386 / jdsample-sse2.asm" , "simd / i386 / jfdctflt-3dn.asm" , "simd / i386 / jfdctflt-sse.asm" , "simd / i386 / jfdctfst-mmx.asm" , "simd / i386 / jfdctfst-sse2.asm" , "simd / i386 / jfdctint-avx2.asm" , "simd / i386 / jfdctint-mmx.asm" , "simd / i386 / jfdctint-sse2.asm" , "simd / i386 / jidctflt-3dn.asm" , "simd / i386 / jidctflt-sse.asm" , "simd / i386 / jidctflt-sse2.asm" , "simd / i386 / jidctfst-mmx.asm" , "simd / i386 / jidctfst-sse2.asm" , "simd / i386 / jidctint-avx2.asm" , "simd / i386 / jidctint-mmx.asm" , "simd / i386 / jidctint-sse2.asm" , "simd / i386 / jidctred-mmx.asm" , "simd / i386 / jidctred-sse2.asm" , "simd / i386 / jquant-3dn.asm" , "simd / i386 / jquant-mmx.asm" , "simd / i386 / jquant-sse.asm" , "simd / i386 / jquantf-sse2.asm" , "simd / i386 / jquanti-avx2.asm" , "simd / i386 / jquanti-sse2.asm" , "simd / i386 / jsimd.c" , "simd / i386 / jsimdcpu.asm" , ], asflags : [ "-DPIC" , ], local_include_dirs : [ "simd" , "simd / nasm" , ], }, x86_64 : { // x86-64 SSE2 srcs : [ "simd / x86_64 / jccolor-avx2.asm" , "simd / x86_64 / jccolor-sse2.asm" , "simd / x86_64 / jcgray-avx2.asm" , "simd / x86_64 / jcgray-sse2.asm" , "simd / x86_64 / jchuff-sse2.asm" , "simd / x86_64 / jcphuff-sse2.asm" , "simd / x86_64 / jcsample-avx2.asm" , "simd / x86_64 / jcsample-sse2.asm" , "simd / x86_64 / jdcolor-avx2.asm" , "simd / x86_64 / jdcolor-sse2.asm" , "simd / x86_64 / jdmerge-avx2.asm" , "simd / x86_64 / jdmerge-sse2.asm" , "simd / x86_64 / jdsample-avx2.asm" , "simd / x86_64 / jdsample-sse2.asm" , "simd / x86_64 / jfdctflt-sse.asm" , "simd / x86_64 / jfdctfst-sse2.asm" , "simd / x86_64 / jfdctint-avx2.asm" , "simd / x86_64 / jfdctint-sse2.asm" , "simd / x86_64 / jidctflt-sse2.asm" , "simd / x86_64 / jidctfst-sse2.asm" , "simd / x86_64 / jidctint-avx2.asm" , "simd / x86_64 / jidctint-sse2.asm" , "simd / x86_64 / jidctred-sse2.asm" , "simd / x86_64 / jquantf-sse2.asm" , "simd / x86_64 / jquanti-avx2.asm" , "simd / x86_64 / jquanti-sse2.asm" , "simd / x86_64 / jsimd.c" , "simd / x86_64 / jsimdcpu.asm" , ], asflags : [ "-DPIC" , "-D__x86_64__" , ], local_include_dirs : [ "simd" , "simd / nasm" , ], }, mips : { srcs : [ "jsimd_none.c" ], }, mips64 : { srcs : [ "jsimd_none.c" ], }, }, objetivo : { linux : { asflags : [ "-DELF" , ], }, darwin : { asflags : [ "-DMACHO" , ], }, windows_x86 : { asflags : [ "-DWIN32" , ], }, windows_x86_64 : { asflags : [ "-DWIN64" , ], }, },}// También compilar como una biblioteca compartida.cc_library { nombre : "libjpeg" , host_supported : verdadero , vendor_available : verdadero , vndk : { habilitado : verdadero , }, valores predeterminados : [ "libjpeg-defaults" ], export_include_dirs : [ "." ], objetivo : { ventanas : { habilitado : verdadero , }, },}// Construir biblioteca estática contra el NDKcc_library_static { nombre : "libjpeg_static_ndk" , valores predeterminados : [ "libjpeg-defaults" ], export_include_dirs : [ "." ], sdk_version : "17" , }// Definición para TJBenchcc_binary { nombre : "tjbench" , whole_static_libs : [ "libjpeg" ], multilib : { lib32 : { madre : "tj32" , }, lib64 : { madre : "tj64" , }, }, compile_multilib : "ambos" , banderas : [ "-DBMP_SUPPORTED" , "-DPPM_SUPPORTED" , "-Werror" , "-Sin parámetro no utilizado" , ], srcs : [ "jdatadst-tj.c" , "jdatasrc-tj.c" , "rdbmp.c" , "rdppm.c" , "tjbench.c" , "tjutil.c" , "transupp.c" , "turbojpeg.c" , "wrbmp.c" , "wrppm.c" , ],}