### PR TITLE
Adding Spotless rules for Groovy Gradle files and fixes.

### DIFF
--- a/about/build.gradle
+++ b/about/build.gradle
@@ -1,18 +1,17 @@
 /*
- *   Copyright 2018 Google LLC
+ * Copyright 2018 Google LLC.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 apply plugin: 'com.android.dynamic-feature'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,7 +38,7 @@ android {
 
         resConfig 'en'
         manifestPlaceholders += [
-                crashlyticsEnabled: false
+            crashlyticsEnabled: false
         ]
     }
 
@@ -49,7 +49,8 @@ android {
     buildTypes {
         release {
             // There's a Dex Splitter issue when enabling DataBinding & proguard in dynamic features
-            // The temporary workaround is to disable shrinking
+            // The temporary workaround is to disable shrinking.
+            // This issue is tracked in: https://issuetracker.google.com/120517460
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                     'proguard-rules.pro'
@@ -69,7 +70,12 @@ android {
         jvmTarget = "1.8"
     }
 
-    dynamicFeatures = [':about', ':designernews', ':dribbble', ':search']
+    dynamicFeatures = [
+        ':about',
+        ':designernews',
+        ':dribbble',
+        ':search'
+    ]
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -89,5 +89,14 @@ subprojects {
             ktlint(versions.ktlint)
             licenseHeaderFile project.rootProject.file('scripts/copyright.kt')
         }
+        groovyGradle {
+            // same as groovy, but for .gradle (defaults to '*.gradle')
+            target '**/*.gradle'
+            paddedCell() // Avoid cyclic ambiguities
+            // the Groovy Eclipse formatter extends the Java Eclipse formatter,
+            // so it formats Java files by default (unless `excludeJava` is used).
+            greclipse().configFile(project.rootProject.file('scripts/greclipse.properties'))
+            licenseHeaderFile project.rootProject.file('scripts/copyright.kt'), '(buildscript|apply)'
+        }
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,18 +1,17 @@
 /*
- *   Copyright 2018 Google LLC
+ * Copyright 2018 Google LLC.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 apply plugin: 'com.android.library'

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -1,18 +1,17 @@
 /*
- *   Copyright 2018 Google LLC
+ * Copyright 2018 Google LLC.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 apply plugin: 'com.android.dynamic-feature'

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -1,18 +1,17 @@
 /*
- *   Copyright 2018 Google LLC
+ * Copyright 2018 Google LLC.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 apply plugin: 'com.android.dynamic-feature'

--- a/scripts/greclipse.properties
+++ b/scripts/greclipse.properties
@@ -1,0 +1,34 @@
+#Whether to use 'space', 'tab' or 'mixed' (both) characters for indentation.
+#The default value is 'tab'.
+org.eclipse.jdt.core.formatter.tabulation.char=space
+
+#Number of spaces used for indentation in case 'space' characters
+#have been selected. The default value is 4.
+org.eclipse.jdt.core.formatter.tabulation.size=4
+
+#Number of spaces used for indentation in case 'mixed' characters
+#have been selected. The default value is 4.
+org.eclipse.jdt.core.formatter.indentation.size=4
+
+#Whether or not indentation characters are inserted into empty lines.
+#The default value is 'true'.
+org.eclipse.jdt.core.formatter.indent_empty_lines=false
+
+#Number of spaces used for multiline indentation.
+#The default value is 2.
+groovy.formatter.multiline.indentation=2
+
+#Length after which list are considered too long. These will be wrapped.
+#The default value is 30.
+groovy.formatter.longListLength=30
+
+#Whether opening braces position shall be the next line.
+#The default value is 'same'.
+groovy.formatter.braces.start=same
+
+#Whether closing braces position shall be the next line.
+#The default value is 'next'.
+groovy.formatter.braces.end=next
+
+#Remove unnecessary semicolons. The default value is 'false'.
+groovy.formatter.remove.unnecessary.semicolons=false

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -1,18 +1,17 @@
 /*
- *   Copyright 2018 Google LLC
+ * Copyright 2018 Google LLC.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 apply plugin: 'com.android.dynamic-feature'
@@ -53,7 +52,6 @@ dependencies {
     implementation "com.github.bumptech.glide:recyclerview-integration:${versions.glide}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
-
 }
 
 kapt {

--- a/test_shared/build.gradle
+++ b/test_shared/build.gradle
@@ -1,18 +1,17 @@
 /*
- *   Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC.
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 apply plugin: 'com.android.library'
@@ -48,6 +47,5 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
     implementation "junit:junit:${versions.junit}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.coroutines}"
-
 }
 

--- a/third_party/bypass/build.gradle
+++ b/third_party/bypass/build.gradle
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 


### PR DESCRIPTION
- Added spotless rule for Groovy build scripts
- Added groovy configuration (script/greclipse.properties)
- Fixed spotless issues in multiple build.gradle files.

Fixes #808

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Adding Spotless rules for Groovy Gradle files:

- Added spotless rule for Groovy build scripts
- Added groovy configuration (script/greclipse.properties)
- Fixed spotless issues in multiple build.gradle files.

## :bulb: Motivation and Context
For consistency in build.gradle files we can use the spotless plugin to enforce a consistent formatting.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
Profit from the added spotless rules!

## :camera_flash: Screenshots / GIFs
