### PR TITLE
Update Android Gradle plugin to 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-beta03'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"


### PR DESCRIPTION
Android Studio 3.6 is now available:

https://androidstudio.googleblog.com/2020/02/android-studio-36-available-in-stable.html

EDIT:
Requires #792 to be merged first. I'll rebase this PR once #792 is on `master`.