### PR TITLE
[801] Fix HomeToolbar popupTheme in non-night mode

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,7 +30,15 @@
     <style name="Widget.Plaid.HomeToolbar" parent="Widget.Plaid.Toolbar.SmallCapsTitle">
         <item name="android:background">@null</item>
         <item name="android:elevation">0dp</item>
-        <item name="materialThemeOverlay">@style/ThemeOverlay.MaterialComponents.Dark.ActionBar</item>
+        <item name="android:theme">@style/ThemeOverlay.Plaid.HomeToolbar</item>
+    </style>
+
+    <style name="ThemeOverlay.Plaid.HomeToolbar" parent="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
+        <item name="popupTheme">@style/ThemeOverlay.Plaid.HomeToolbar.PopupTheme</item>
+    </style>
+
+    <style name="ThemeOverlay.Plaid.HomeToolbar.PopupTheme" parent="">
+        <item name="android:textColorPrimary">?attr/colorOnSurface</item>
     </style>
 
     <style name="TextAppearance.ToolbarTitleSmallCaps" parent="@style/TextAppearance.MaterialComponents.Headline6">


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
- `materialThemeOverlay` doesn't work with AppCompatToolbar
- since the style is being set explicitly (activity_home), we can use `android:theme`, and this will be applied as an overlay
- the popup menu is already taking `colorSurface` correctly, but not sure why it's not setting the text accordingly. Overriding textColorPrimary to colorOnSurface fixes it, while applying it in a small scope (only to the HomeToolbar's popupTheme) means we won't goof anything else up

## :bulb: Motivation and Context
Fixes #801 - PopMenu has always white text even when in light mode

## :green_heart: How did you test it?
Visually - see screenshots

## :pencil: Checklist
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing

## :crystal_ball: Next steps
Wait for comments

## :camera_flash: Screenshots / GIFs

Before (dark mode) | After
---|---
![plaid-before-dark](https://user-images.githubusercontent.com/2678555/75289886-2b2bbc00-5817-11ea-8cbd-23de21245318.png) | ![plaid-after-dark](https://user-images.githubusercontent.com/2678555/75289894-2ebf4300-5817-11ea-8a54-044e383e27c1.png)

Before (light mode) | After
---|---
![plaid-before](https://user-images.githubusercontent.com/2678555/75289899-2ff07000-5817-11ea-9a34-52c4c74a9a02.png) | ![plaid-after](https://user-images.githubusercontent.com/2678555/75289901-30890680-5817-11ea-98a6-470f3b19ee37.png)
