### PR TITLE
Update Android Gradle plugin to 3.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"


### PR DESCRIPTION
A small patch update to the Android Gradle plugin

https://androidstudio.googleblog.com/2020/02/android-studio-361-available.html